### PR TITLE
feat(frontend): register page with role selector and auth flow

### DIFF
--- a/stellance/frontend/app/(auth)/layout.tsx
+++ b/stellance/frontend/app/(auth)/layout.tsx
@@ -3,7 +3,10 @@ import Link from "next/link";
 
 export const metadata: Metadata = {
   title: {
-    default: "Sign In",
+    // Each auth page (login, register) exports its own title string.
+    // `default` here is the fallback if a nested segment has no title —
+    // using the site name keeps it sensible rather than empty.
+    default: "Stellance",
     template: "%s | Stellance",
   },
 };

--- a/stellance/frontend/app/(auth)/login/LoginForm.tsx
+++ b/stellance/frontend/app/(auth)/login/LoginForm.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { toast } from "sonner";
+import { loginUser, AuthApiError, extractErrorMessage } from "@/lib/api/auth";
+
+// ─── Validation schema ────────────────────────────────────────────────────────
+
+const loginSchema = z.object({
+  email: z
+    .string()
+    .min(1, "Email is required.")
+    .email("Please enter a valid email address."),
+  password: z.string().min(1, "Password is required."),
+});
+
+type LoginFormValues = z.infer<typeof loginSchema>;
+
+// ─── Small primitives ─────────────────────────────────────────────────────────
+
+/** Inline field-level validation error with a stable id for aria-describedby. */
+function FieldError({ id, message }: { id: string; message?: string }) {
+  if (!message) return null;
+  return (
+    <p id={id} role="alert" className="mt-1 text-xs text-error">
+      {message}
+    </p>
+  );
+}
+
+/**
+ * Eye toggle icon.
+ * `visible={true}` → eye-open (password is readable)
+ * `visible={false}` → eye-off (password is hidden)
+ */
+function EyeIcon({ visible }: { visible: boolean }) {
+  return visible ? (
+    // Eye-open: password is currently visible
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden={true}
+    >
+      <path d="M1 12S5 4 12 4s11 8 11 8-4 8-11 8S1 12 1 12z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  ) : (
+    // Eye-off: password is currently hidden
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden={true}
+    >
+      <path d="M17.94 17.94A10.07 10.07 0 0112 20C7 20 2.73 16.11 1 12a18.45 18.45 0 015.06-5.94" />
+      <path d="M9.9 4.24A9.12 9.12 0 0112 4c5 0 9.27 3.89 11 8a18.5 18.5 0 01-2.16 3.19" />
+      <line x1="1" y1="1" x2="23" y2="23" />
+    </svg>
+  );
+}
+
+// ─── Login form ───────────────────────────────────────────────────────────────
+
+export function LoginForm() {
+  const router = useRouter();
+  const [showPassword, setShowPassword] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<LoginFormValues>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: { email: "", password: "" },
+  });
+
+  async function onSubmit(values: LoginFormValues) {
+    setServerError(null);
+
+    try {
+      const data = await loginUser(values);
+
+      // Persist the access token for subsequent API calls.
+      // The refresh_token is handled server-side as an httpOnly cookie.
+      sessionStorage.setItem("access_token", data.access_token);
+
+      toast.success(
+        `Welcome back${data.user.email ? `, ${data.user.email}` : ""}!`
+      );
+      router.push("/dashboard/jobs");
+    } catch (err) {
+      // 401 from LocalAuthGuard = wrong credentials. The backend returns a
+      // generic message for 401/403; override with a user-friendly string.
+      // extractErrorMessage returns the API body as-is for other error codes.
+      const isCredentialError =
+        err instanceof AuthApiError &&
+        (err.status === 401 || err.status === 403);
+
+      const message = extractErrorMessage(
+        err,
+        isCredentialError
+          ? "Invalid email or password."
+          : "Something went wrong. Please try again."
+      );
+
+      setServerError(message);
+    }
+  }
+
+  // ─── Render ──────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="card-surface glow-accent p-8 sm:p-10">
+      {/* Heading */}
+      <div className="mb-8 text-center">
+        <h1 className="text-2xl font-semibold tracking-tight text-white">
+          Sign in to Stellance
+        </h1>
+        <p className="mt-1 text-sm text-text-muted">
+          Enter your email and password to continue.
+        </p>
+      </div>
+
+      {/* Server-level error banner */}
+      {serverError && (
+        <div
+          role="alert"
+          className="mb-6 flex items-start gap-3 rounded-md border border-error/30 bg-error/10 px-4 py-3 text-sm text-error"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="mt-0.5 shrink-0"
+            aria-hidden={true}
+          >
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="12" />
+            <line x1="12" y1="16" x2="12.01" y2="16" />
+          </svg>
+          {serverError}
+        </div>
+      )}
+
+      {/* Form */}
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        noValidate
+        className="space-y-5"
+        aria-label="Login form"
+      >
+        {/* Email */}
+        <div>
+          <label
+            htmlFor="email"
+            className="mb-1.5 block text-sm font-medium text-text-primary"
+          >
+            Email address
+          </label>
+          <input
+            id="email"
+            type="email"
+            autoComplete="email"
+            autoFocus
+            placeholder="you@example.com"
+            aria-invalid={!!errors.email}
+            aria-describedby={errors.email ? "email-error" : undefined}
+            className={[
+              "w-full rounded-md border bg-navy px-3.5 py-2.5 text-sm text-text-primary placeholder:text-text-muted/60",
+              "transition-colors duration-150 outline-none",
+              "focus:border-accent focus:ring-1 focus:ring-accent",
+              errors.email
+                ? "border-error focus:border-error focus:ring-error"
+                : "border-slate-border",
+            ].join(" ")}
+            {...register("email")}
+          />
+          <FieldError id="email-error" message={errors.email?.message} />
+        </div>
+
+        {/* Password */}
+        <div>
+          <div className="mb-1.5 flex items-center justify-between">
+            <label
+              htmlFor="password"
+              className="text-sm font-medium text-text-primary"
+            >
+              Password
+            </label>
+            {/* Placeholder — link to forgot-password when that page exists */}
+            <span className="text-xs text-text-muted cursor-not-allowed select-none">
+              Forgot password?
+            </span>
+          </div>
+
+          <div className="relative">
+            <input
+              id="password"
+              type={showPassword ? "text" : "password"}
+              autoComplete="current-password"
+              placeholder="••••••••"
+              aria-invalid={!!errors.password}
+              aria-describedby={errors.password ? "password-error" : undefined}
+              className={[
+                "w-full rounded-md border bg-navy px-3.5 py-2.5 pr-10 text-sm text-text-primary placeholder:text-text-muted/60",
+                "transition-colors duration-150 outline-none",
+                "focus:border-accent focus:ring-1 focus:ring-accent",
+                errors.password
+                  ? "border-error focus:border-error focus:ring-error"
+                  : "border-slate-border",
+              ].join(" ")}
+              {...register("password")}
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword((v) => !v)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted hover:text-text-primary transition-colors"
+              aria-label={showPassword ? "Hide password" : "Show password"}
+            >
+              {/* visible=showPassword: eye-open when password is readable */}
+              <EyeIcon visible={showPassword} />
+            </button>
+          </div>
+          <FieldError id="password-error" message={errors.password?.message} />
+        </div>
+
+        {/* Submit */}
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className={[
+            "mt-2 w-full rounded-md px-4 py-2.5 text-sm font-semibold text-white",
+            "bg-accent hover:bg-accent-hover active:scale-[0.98]",
+            "transition-all duration-150 focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-slate-panel",
+            "disabled:opacity-60 disabled:cursor-not-allowed disabled:active:scale-100",
+          ].join(" ")}
+        >
+          {isSubmitting ? (
+            <span className="flex items-center justify-center gap-2">
+              <svg
+                className="h-4 w-4 animate-spin"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                aria-hidden={true}
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                />
+              </svg>
+              Signing in…
+            </span>
+          ) : (
+            "Sign in"
+          )}
+        </button>
+      </form>
+
+      {/* Register link */}
+      <p className="mt-6 text-center text-sm text-text-muted">
+        Don&apos;t have an account?{" "}
+        <Link
+          href="/register"
+          className="font-medium text-accent hover:text-accent-bright transition-colors"
+        >
+          Create one
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/stellance/frontend/app/(auth)/register/RegisterForm.tsx
+++ b/stellance/frontend/app/(auth)/register/RegisterForm.tsx
@@ -1,0 +1,517 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { toast } from "sonner";
+import {
+  registerUser,
+  extractErrorMessage,
+  type UserRole,
+} from "@/lib/api/auth";
+
+// ─── Validation schema ────────────────────────────────────────────────────────
+
+const registerSchema = z
+  .object({
+    role: z.enum(["FREELANCER", "CLIENT"], {
+      required_error: "Please select a role to continue.",
+    }),
+    name: z
+      .string()
+      .min(1, "Full name is required.")
+      .max(100, "Name must be 100 characters or fewer."),
+    email: z
+      .string()
+      .min(1, "Email is required.")
+      .email("Please enter a valid email address."),
+    password: z
+      .string()
+      .min(6, "Password must be at least 6 characters.")
+      .max(128, "Password must be 128 characters or fewer."),
+    confirmPassword: z.string().min(1, "Please confirm your password."),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match.",
+    path: ["confirmPassword"],
+  });
+
+type RegisterFormValues = z.infer<typeof registerSchema>;
+
+// ─── Small primitives ─────────────────────────────────────────────────────────
+
+function FieldError({ id, message }: { id: string; message?: string }) {
+  if (!message) return null;
+  return (
+    <p id={id} role="alert" className="mt-1 text-xs text-error">
+      {message}
+    </p>
+  );
+}
+
+function EyeIcon({ visible }: { visible: boolean }) {
+  return visible ? (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden={true}
+    >
+      <path d="M1 12S5 4 12 4s11 8 11 8-4 8-11 8S1 12 1 12z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  ) : (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden={true}
+    >
+      <path d="M17.94 17.94A10.07 10.07 0 0112 20C7 20 2.73 16.11 1 12a18.45 18.45 0 015.06-5.94" />
+      <path d="M9.9 4.24A9.12 9.12 0 0112 4c5 0 9.27 3.89 11 8a18.5 18.5 0 01-2.16 3.19" />
+      <line x1="1" y1="1" x2="23" y2="23" />
+    </svg>
+  );
+}
+
+// ─── Role option card ─────────────────────────────────────────────────────────
+
+interface RoleCardProps {
+  value: UserRole;
+  selected: boolean;
+  onSelect: (role: UserRole) => void;
+  label: string;
+  description: string;
+  icon: React.ReactNode;
+}
+
+function RoleCard({
+  value,
+  selected,
+  onSelect,
+  label,
+  description,
+  icon,
+}: RoleCardProps) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={selected}
+      onClick={() => onSelect(value)}
+      className={[
+        "flex flex-1 flex-col items-start gap-2 rounded-md border p-4 text-left transition-all duration-150",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-slate-panel",
+        selected
+          ? "border-accent bg-accent/10 shadow-[0_0_0_1px_theme(colors.accent)]"
+          : "border-slate-border bg-navy hover:border-accent/50",
+      ].join(" ")}
+    >
+      <span
+        className={[
+          "flex h-9 w-9 items-center justify-center rounded-md",
+          selected
+            ? "bg-accent/20 text-accent"
+            : "bg-slate-border/50 text-text-muted",
+        ].join(" ")}
+      >
+        {icon}
+      </span>
+      <span className="text-sm font-semibold text-white">{label}</span>
+      <span className="text-xs text-text-muted leading-relaxed">
+        {description}
+      </span>
+      <span className="sr-only">{selected ? "Selected" : "Not selected"}</span>
+    </button>
+  );
+}
+
+// ─── Register form ────────────────────────────────────────────────────────────
+
+export function RegisterForm() {
+  const router = useRouter();
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    setValue,
+    formState: { errors, isSubmitting },
+  } = useForm<RegisterFormValues>({
+    resolver: zodResolver(registerSchema),
+    defaultValues: {
+      role: undefined,
+      name: "",
+      email: "",
+      password: "",
+      confirmPassword: "",
+    },
+  });
+
+  const selectedRole = watch("role");
+
+  function handleRoleSelect(role: UserRole) {
+    setValue("role", role, { shouldValidate: true });
+  }
+
+  async function onSubmit(values: RegisterFormValues) {
+    setServerError(null);
+
+    try {
+      const data = await registerUser({
+        name: values.name,
+        email: values.email,
+        password: values.password,
+        role: values.role as UserRole,
+      });
+
+      // Persist access token; refresh_token is set as httpOnly cookie by the backend.
+      sessionStorage.setItem("access_token", data.access_token);
+
+      toast.success("Account created! Let's set up your wallet.");
+      router.push("/wallet/setup");
+    } catch (err) {
+      // AuthApiError: the backend returns a descriptive message directly (e.g.
+      // "Email already exists" for 409, or field-level messages for 400s).
+      // extractErrorMessage surfaces those as-is; the fallback only fires for
+      // non-API errors such as network failures.
+      const message = extractErrorMessage(
+        err,
+        "Something went wrong. Please try again."
+      );
+      setServerError(message);
+    }
+  }
+
+  return (
+    <div className="card-surface glow-accent p-8 sm:p-10">
+      {/* Heading */}
+      <div className="mb-8 text-center">
+        <h1 className="text-2xl font-semibold tracking-tight text-white">
+          Create your account
+        </h1>
+        <p className="mt-1 text-sm text-text-muted">
+          Join Stellance — secure freelance payments on Stellar.
+        </p>
+      </div>
+
+      {/* Server-level error banner */}
+      {serverError && (
+        <div
+          role="alert"
+          className="mb-6 flex items-start gap-3 rounded-md border border-error/30 bg-error/10 px-4 py-3 text-sm text-error"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="mt-0.5 shrink-0"
+            aria-hidden={true}
+          >
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="12" />
+            <line x1="12" y1="16" x2="12.01" y2="16" />
+          </svg>
+          {serverError}
+        </div>
+      )}
+
+      <form
+        onSubmit={handleSubmit(onSubmit)}
+        noValidate
+        className="space-y-5"
+        aria-label="Registration form"
+      >
+        {/* ── Role selector ────────────────────────────────────────────────── */}
+        <fieldset>
+          <legend className="mb-2 block text-sm font-medium text-text-primary">
+            I want to…
+          </legend>
+
+          <div role="radiogroup" aria-label="Account role" className="flex gap-3">
+            <RoleCard
+              value="FREELANCER"
+              selected={selectedRole === "FREELANCER"}
+              onSelect={handleRoleSelect}
+              label="Work as a freelancer"
+              description="Offer services, receive milestone payments, and get paid on-chain."
+              icon={
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden={true}
+                >
+                  <rect x="2" y="7" width="20" height="14" rx="2" ry="2" />
+                  <path d="M16 7V5a2 2 0 00-2-2h-4a2 2 0 00-2 2v2" />
+                  <line x1="12" y1="12" x2="12" y2="12" />
+                  <path d="M2 12h20" />
+                </svg>
+              }
+            />
+            <RoleCard
+              value="CLIENT"
+              selected={selectedRole === "CLIENT"}
+              onSelect={handleRoleSelect}
+              label="Hire a freelancer"
+              description="Post jobs, fund escrow, and release payments when work is approved."
+              icon={
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden={true}
+                >
+                  <path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z" />
+                  <polyline points="9 22 9 12 15 12 15 22" />
+                </svg>
+              }
+            />
+          </div>
+          {errors.role && (
+            <p role="alert" className="mt-1.5 text-xs text-error">
+              {errors.role.message}
+            </p>
+          )}
+        </fieldset>
+
+        {/* ── Full name ────────────────────────────────────────────────────── */}
+        <div>
+          <label
+            htmlFor="name"
+            className="mb-1.5 block text-sm font-medium text-text-primary"
+          >
+            Full name
+          </label>
+          <input
+            id="name"
+            type="text"
+            autoComplete="name"
+            autoFocus
+            placeholder="Alice Smith"
+            aria-invalid={!!errors.name}
+            aria-describedby={errors.name ? "name-error" : undefined}
+            className={[
+              "w-full rounded-md border bg-navy px-3.5 py-2.5 text-sm text-text-primary placeholder:text-text-muted/60",
+              "transition-colors duration-150 outline-none",
+              "focus:border-accent focus:ring-1 focus:ring-accent",
+              errors.name
+                ? "border-error focus:border-error focus:ring-error"
+                : "border-slate-border",
+            ].join(" ")}
+            {...register("name")}
+          />
+          <FieldError id="name-error" message={errors.name?.message} />
+        </div>
+
+        {/* ── Email ────────────────────────────────────────────────────────── */}
+        <div>
+          <label
+            htmlFor="email"
+            className="mb-1.5 block text-sm font-medium text-text-primary"
+          >
+            Email address
+          </label>
+          <input
+            id="email"
+            type="email"
+            autoComplete="email"
+            placeholder="you@example.com"
+            aria-invalid={!!errors.email}
+            aria-describedby={errors.email ? "email-error" : undefined}
+            className={[
+              "w-full rounded-md border bg-navy px-3.5 py-2.5 text-sm text-text-primary placeholder:text-text-muted/60",
+              "transition-colors duration-150 outline-none",
+              "focus:border-accent focus:ring-1 focus:ring-accent",
+              errors.email
+                ? "border-error focus:border-error focus:ring-error"
+                : "border-slate-border",
+            ].join(" ")}
+            {...register("email")}
+          />
+          <FieldError id="email-error" message={errors.email?.message} />
+        </div>
+
+        {/* ── Password ─────────────────────────────────────────────────────── */}
+        <div>
+          <label
+            htmlFor="password"
+            className="mb-1.5 block text-sm font-medium text-text-primary"
+          >
+            Password
+          </label>
+          <div className="relative">
+            <input
+              id="password"
+              type={showPassword ? "text" : "password"}
+              autoComplete="new-password"
+              placeholder="••••••••"
+              aria-invalid={!!errors.password}
+              aria-describedby={
+                errors.password ? "password-error" : "password-hint"
+              }
+              className={[
+                "w-full rounded-md border bg-navy px-3.5 py-2.5 pr-10 text-sm text-text-primary placeholder:text-text-muted/60",
+                "transition-colors duration-150 outline-none",
+                "focus:border-accent focus:ring-1 focus:ring-accent",
+                errors.password
+                  ? "border-error focus:border-error focus:ring-error"
+                  : "border-slate-border",
+              ].join(" ")}
+              {...register("password")}
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword((v) => !v)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted hover:text-text-primary transition-colors"
+              aria-label={showPassword ? "Hide password" : "Show password"}
+            >
+              <EyeIcon visible={showPassword} />
+            </button>
+          </div>
+          {errors.password ? (
+            <FieldError
+              id="password-error"
+              message={errors.password.message}
+            />
+          ) : (
+            <p id="password-hint" className="mt-1 text-xs text-text-muted">
+              Minimum 6 characters.
+            </p>
+          )}
+        </div>
+
+        {/* ── Confirm password ─────────────────────────────────────────────── */}
+        <div>
+          <label
+            htmlFor="confirmPassword"
+            className="mb-1.5 block text-sm font-medium text-text-primary"
+          >
+            Confirm password
+          </label>
+          <div className="relative">
+            <input
+              id="confirmPassword"
+              type={showConfirm ? "text" : "password"}
+              autoComplete="new-password"
+              placeholder="••••••••"
+              aria-invalid={!!errors.confirmPassword}
+              aria-describedby={
+                errors.confirmPassword ? "confirm-error" : undefined
+              }
+              className={[
+                "w-full rounded-md border bg-navy px-3.5 py-2.5 pr-10 text-sm text-text-primary placeholder:text-text-muted/60",
+                "transition-colors duration-150 outline-none",
+                "focus:border-accent focus:ring-1 focus:ring-accent",
+                errors.confirmPassword
+                  ? "border-error focus:border-error focus:ring-error"
+                  : "border-slate-border",
+              ].join(" ")}
+              {...register("confirmPassword")}
+            />
+            <button
+              type="button"
+              onClick={() => setShowConfirm((v) => !v)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted hover:text-text-primary transition-colors"
+              aria-label={showConfirm ? "Hide password" : "Show password"}
+            >
+              <EyeIcon visible={showConfirm} />
+            </button>
+          </div>
+          <FieldError
+            id="confirm-error"
+            message={errors.confirmPassword?.message}
+          />
+        </div>
+
+        {/* ── Submit ───────────────────────────────────────────────────────── */}
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className={[
+            "mt-2 w-full rounded-md px-4 py-2.5 text-sm font-semibold text-white",
+            "bg-accent hover:bg-accent-hover active:scale-[0.98]",
+            "transition-all duration-150 focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-slate-panel",
+            "disabled:opacity-60 disabled:cursor-not-allowed disabled:active:scale-100",
+          ].join(" ")}
+        >
+          {isSubmitting ? (
+            <span className="flex items-center justify-center gap-2">
+              <svg
+                className="h-4 w-4 animate-spin"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                aria-hidden={true}
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                />
+              </svg>
+              Creating account…
+            </span>
+          ) : (
+            "Create account"
+          )}
+        </button>
+      </form>
+
+      {/* Login link */}
+      <p className="mt-6 text-center text-sm text-text-muted">
+        Already have an account?{" "}
+        <Link
+          href="/login"
+          className="font-medium text-accent hover:text-accent-bright transition-colors"
+        >
+          Sign in
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/stellance/frontend/app/(auth)/register/page.tsx
+++ b/stellance/frontend/app/(auth)/register/page.tsx
@@ -1,16 +1,18 @@
 import type { Metadata } from "next";
-import { LoginForm } from "./LoginForm";
+import { RegisterForm } from "./RegisterForm";
 
 // ─── Metadata ─────────────────────────────────────────────────────────────────
-// Auth layout sets template: "%s | Stellance" → "Sign In | Stellance".
+// The auth layout sets template: "%s | Stellance", so the browser title
+// becomes "Create Account | Stellance".
 
 export const metadata: Metadata = {
-  title: "Sign In",
-  description: "Sign in to your Stellance account.",
+  title: "Create Account",
+  description:
+    "Sign up for Stellance and choose your role — freelancer or client — to start using instant on-chain escrow payments.",
 };
 
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
-export default function LoginPage() {
-  return <LoginForm />;
+export default function RegisterPage() {
+  return <RegisterForm />;
 }

--- a/stellance/frontend/app/page.tsx
+++ b/stellance/frontend/app/page.tsx
@@ -78,15 +78,29 @@ export default function Home() {
           <div className="hidden sm:flex items-center gap-6 md:gap-8 text-sm" style={{ color: "#9ca3af" }}>
             <a href="#how-it-works" className="hover:text-white transition-colors">How it works</a>
             <a href="#features" className="hover:text-white transition-colors hidden md:inline">Features</a>
-            <a href="/demo" className="hover:text-white transition-colors hidden md:inline">Demo</a>
             <a
               href="https://github.com/alone-in/stellances"
               target="_blank"
               rel="noreferrer"
-              className="hover:text-white transition-colors"
+              className="hover:text-white transition-colors hidden md:inline"
             >
               ↗ GitHub
             </a>
+            <Link href="/login" className="hover:text-white transition-colors">
+              Sign in
+            </Link>
+            <Link
+              href="/register"
+              style={{
+                display: "inline-flex", alignItems: "center",
+                background: "linear-gradient(90deg, #7c3aed 0%, #0ea5e9 100%)",
+                color: "#fff", fontWeight: 600,
+                fontSize: "0.8rem", padding: "0.45rem 1rem", borderRadius: "6px",
+                textDecoration: "none",
+              }}
+            >
+              Get started
+            </Link>
           </div>
         </div>
       </nav>
@@ -106,7 +120,7 @@ export default function Home() {
               }}
             >
               <span style={{ width: 6, height: 6, borderRadius: "50%", backgroundColor: "#a78bfa", display: "inline-block" }} />
-              Stellar network · Testnet live · Open source
+              Stellar network · Instant settlement · Open source
             </p>
 
             {/* Headline */}
@@ -156,7 +170,7 @@ export default function Home() {
             {/* CTAs */}
             <div className="flex flex-row gap-3 mt-8 flex-wrap">
               <Link
-                href="/demo"
+                href="/register"
                 style={{
                   display: "inline-flex", alignItems: "center", justifyContent: "center", gap: "0.5rem",
                   background: "linear-gradient(90deg, #7c3aed 0%, #0ea5e9 100%)",
@@ -166,7 +180,7 @@ export default function Home() {
                   boxShadow: "0 0 24px rgba(124,58,237,0.4)",
                 }}
               >
-                Try testnet demo →
+                Get started free →
               </Link>
               <a
                 href="https://github.com/alone-in/stellances"
@@ -381,7 +395,7 @@ export default function Home() {
       <section className="py-16 sm:py-24" style={{ borderBottom: "1px solid rgba(167,139,250,0.15)" }}>
         <div className="max-w-7xl mx-auto px-4 sm:px-8 text-center">
           <p style={{ fontSize: "0.75rem", textTransform: "uppercase", letterSpacing: "0.12em", color: "#a78bfa", marginBottom: "1rem" }}>
-            See it live
+            Get started
           </p>
           <h2
             style={{
@@ -391,14 +405,14 @@ export default function Home() {
               letterSpacing: "-0.03em", marginBottom: "1rem",
             }}
           >
-            See it on the Stellar testnet —<br className="hidden sm:inline" /> no signup required.
+            Start getting paid on-chain —<br className="hidden sm:inline" /> in under a minute.
           </h2>
           <p style={{ fontSize: "0.95rem", color: "#64748b", marginBottom: "2rem", maxWidth: "36rem", margin: "0 auto 2rem" }}>
-            Generate a keypair, fund it with Friendbot, and watch a payment settle in under 5 seconds.
+            Create your account, connect your Stellar wallet, and post or accept your first job. No platform custody, no settlement delays.
           </p>
           <div className="flex flex-col sm:flex-row gap-3 justify-center">
             <Link
-              href="/demo"
+              href="/register"
               style={{
                 display: "inline-flex", alignItems: "center", justifyContent: "center", gap: "0.5rem",
                 background: "linear-gradient(90deg, #7c3aed 0%, #0ea5e9 100%)",
@@ -408,11 +422,10 @@ export default function Home() {
                 boxShadow: "0 0 24px rgba(124,58,237,0.4)",
               }}
             >
-              Try the demo →
+              Create free account →
             </Link>
-            <a
-              href="https://github.com/alone-in/stellances"
-              target="_blank" rel="noreferrer"
+            <Link
+              href="/login"
               style={{
                 display: "inline-flex", alignItems: "center", justifyContent: "center", gap: "0.5rem",
                 border: "1px solid rgba(167,139,250,0.3)", color: "#c4b5fd",
@@ -421,8 +434,8 @@ export default function Home() {
                 backgroundColor: "rgba(167,139,250,0.05)",
               }}
             >
-              GitHub ↗
-            </a>
+              Sign in
+            </Link>
           </div>
         </div>
       </section>
@@ -441,7 +454,8 @@ export default function Home() {
             <nav className="flex flex-wrap gap-x-6 gap-y-2" style={{ fontSize: "0.8rem" }}>
               <a href="#how-it-works" className="hover:text-white transition-colors" style={{ color: "#64748b" }}>How it works</a>
               <a href="#features" className="hover:text-white transition-colors" style={{ color: "#64748b" }}>Features</a>
-              <Link href="/demo" className="hover:text-white transition-colors" style={{ color: "#64748b" }}>Demo</Link>
+              <Link href="/login" className="hover:text-white transition-colors" style={{ color: "#64748b" }}>Sign in</Link>
+              <Link href="/register" className="hover:text-white transition-colors" style={{ color: "#64748b" }}>Sign up</Link>
               <a href="https://github.com/alone-in/stellances" target="_blank" rel="noreferrer" className="hover:text-white transition-colors" style={{ color: "#64748b" }}>GitHub ↗</a>
               <a href="https://github.com/alone-in/stellances/blob/main/CONTRIBUTING.md" target="_blank" rel="noreferrer" className="hover:text-white transition-colors" style={{ color: "#64748b" }}>Contributing</a>
               <a href="https://github.com/alone-in/stellances/blob/main/docs/architecture.md" target="_blank" rel="noreferrer" className="hover:text-white transition-colors" style={{ color: "#64748b" }}>Docs</a>

--- a/stellance/frontend/lib/api/auth.ts
+++ b/stellance/frontend/lib/api/auth.ts
@@ -84,6 +84,8 @@ async function post<T>(path: string, body: unknown): Promise<T> {
 
 // ─── Auth API ─────────────────────────────────────────────────────────────────
 
+export type UserRole = "FREELANCER" | "CLIENT";
+
 export interface LoginPayload {
   email: string;
   password: string;
@@ -91,4 +93,23 @@ export interface LoginPayload {
 
 export async function loginUser(payload: LoginPayload): Promise<LoginResponse> {
   return post<LoginResponse>("/auth/login", payload);
+}
+
+export interface RegisterPayload {
+  name: string;
+  email: string;
+  password: string;
+  role: UserRole;
+}
+
+export interface RegisterResponse {
+  message: string;
+  access_token: string;
+  user: AuthUser;
+}
+
+export async function registerUser(
+  payload: RegisterPayload
+): Promise<RegisterResponse> {
+  return post<RegisterResponse>("/auth/register", payload);
 }


### PR DESCRIPTION
## Summary

Implements the registration page and wires it into the auth flow.

### Changes

**`app/(auth)/register/`** (new)
- `RegisterForm.tsx` — client component with full form logic: role selector (FREELANCER / CLIENT card UI), name, email, password, confirm-password, zod schema with cross-field refine, react-hook-form, server error banner, loading spinner, redirect to `/wallet/setup` on success
- `page.tsx` — server component that exports `metadata: { title: "Create Account" }` and renders `<RegisterForm />`

**`app/(auth)/login/`** (refactored)
- `LoginForm.tsx` — login form extracted to its own client component file
- `page.tsx` — now a server component exporting `metadata: { title: "Sign In" }`

> Next.js does not allow `export const metadata` in `"use client"` files. Splitting each auth route into a server page wrapper + client form component is the correct pattern.

**`app/(auth)/layout.tsx`**
- Fixed metadata: removed stale `default: "Sign In"` that would have rendered as the title for every auth page without its own metadata. Now uses `default: "Stellance"` + `template: "%s | Stellance"`.

**`lib/api/auth.ts`**
- Added `UserRole`, `RegisterPayload`, `RegisterResponse` types and `registerUser()` function targeting `POST /auth/register`

**`app/page.tsx`** (landing page)
- Replaced all `/demo` CTAs with `/register` and `/login`
- Nav: added Sign in + Get started pill button, removed Demo link
- Hero badge: updated copy
- Footer CTA: rewritten as signup call-to-action
- Footer nav: Demo → Sign in + Sign up

### What was tested
- `tsc --noEmit`: 0 errors
- `eslint`: 0 errors (1 React Compiler advisory warning on `watch("role")` — known ecosystem limitation with react-hook-form, not a bug)
- Validated API contract against `POST /auth/register` DTO (`RegisterDto`) and `auth.service.ts`
- Confirmed 409 conflict flow: backend throws `ConflictException` → HTTP 409 → `extractErrorMessage` surfaces `"Email already exists"` directly