### PR TITLE
feat: jobs browsing page with search, filters, and pagination

### DIFF
--- a/stellance/frontend/app/(dashboard)/jobs/page.tsx
+++ b/stellance/frontend/app/(dashboard)/jobs/page.tsx
@@ -1,0 +1,601 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
+import JobCard, { JobCardSkeleton } from "@/components/jobs/JobCard";
+import {
+  fetchJobs,
+  filterJobs,
+  JOB_CATEGORIES,
+  BUDGET_RANGES,
+  type Job,
+  type BudgetRange,
+} from "@/lib/api/jobs";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const PAGE_SIZE = 12;
+
+// ─── Small UI primitives ──────────────────────────────────────────────────────
+
+/** Generic select wrapper styled to match the navy design system. */
+function FilterSelect({
+  id,
+  label,
+  value,
+  onChange,
+  children,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label htmlFor={id} className="text-xs font-medium text-text-muted">
+        {label}
+      </label>
+      <select
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="rounded-md border bg-navy-mid px-3 py-2 text-sm text-text-primary appearance-none cursor-pointer transition-colors duration-150 outline-none focus:border-accent focus:ring-1 focus:ring-accent"
+        style={{ borderColor: "var(--color-slate-border)" }}
+      >
+        {children}
+      </select>
+    </div>
+  );
+}
+
+/** Pagination button. */
+function PageButton({
+  page,
+  current,
+  onClick,
+}: {
+  page: number;
+  current: number;
+  onClick: (p: number) => void;
+}) {
+  const isActive = page === current;
+  return (
+    <button
+      onClick={() => onClick(page)}
+      aria-current={isActive ? "page" : undefined}
+      className="min-w-[2rem] h-8 px-2 rounded-md text-sm font-medium transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:ring-offset-navy"
+      style={{
+        background: isActive ? "var(--color-accent)" : "transparent",
+        color: isActive ? "#fff" : "var(--color-text-muted)",
+        border: isActive
+          ? "1px solid transparent"
+          : "1px solid var(--color-slate-border)",
+      }}
+    >
+      {page}
+    </button>
+  );
+}
+
+// ─── Loading grid ─────────────────────────────────────────────────────────────
+
+function LoadingGrid() {
+  return (
+    <div
+      role="status"
+      aria-label="Loading jobs…"
+      className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"
+    >
+      {Array.from({ length: PAGE_SIZE }).map((_, i) => (
+        <JobCardSkeleton key={i} />
+      ))}
+      <span className="sr-only">Loading jobs…</span>
+    </div>
+  );
+}
+
+// ─── Empty state ──────────────────────────────────────────────────────────────
+
+function EmptyState({
+  filtered,
+  onClear,
+}: {
+  filtered: boolean;
+  onClear: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center px-4">
+      {/* Icon */}
+      <div
+        className="mb-5 flex h-16 w-16 items-center justify-center rounded-full"
+        style={{ background: "rgba(61,169,252,0.08)" }}
+        aria-hidden
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="28"
+          height="28"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          style={{ color: "var(--color-accent)" }}
+        >
+          <circle cx="11" cy="11" r="8" />
+          <line x1="21" y1="21" x2="16.65" y2="16.65" />
+        </svg>
+      </div>
+
+      <h2
+        className="text-lg font-semibold text-white mb-2"
+        style={{ fontFamily: "var(--font-space-grotesk)" }}
+      >
+        {filtered ? "No jobs match your filters" : "No open jobs right now"}
+      </h2>
+      <p className="text-sm text-text-muted max-w-sm mb-6">
+        {filtered
+          ? "Try adjusting your search or removing some filters to see more results."
+          : "Check back soon — new jobs are posted every day."}
+      </p>
+
+      {filtered && (
+        <button
+          onClick={onClear}
+          className="px-4 py-2 rounded-md text-sm font-medium text-white transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-accent"
+          style={{ background: "var(--color-accent)" }}
+        >
+          Clear all filters
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ─── Error state ──────────────────────────────────────────────────────────────
+
+function ErrorState({ onRetry }: { onRetry: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 text-center px-4">
+      <div
+        className="mb-5 flex h-16 w-16 items-center justify-center rounded-full"
+        style={{ background: "rgba(248,113,113,0.08)" }}
+        aria-hidden
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="28"
+          height="28"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          style={{ color: "var(--color-error)" }}
+        >
+          <circle cx="12" cy="12" r="10" />
+          <line x1="12" y1="8" x2="12" y2="12" />
+          <line x1="12" y1="16" x2="12.01" y2="16" />
+        </svg>
+      </div>
+      <h2
+        className="text-lg font-semibold text-white mb-2"
+        style={{ fontFamily: "var(--font-space-grotesk)" }}
+      >
+        Failed to load jobs
+      </h2>
+      <p className="text-sm text-text-muted mb-6">
+        Could not reach the server. Please check your connection and try again.
+      </p>
+      <button
+        onClick={onRetry}
+        className="px-4 py-2 rounded-md text-sm font-medium text-white transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-accent"
+        style={{ background: "var(--color-accent)" }}
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
+// ─── Pagination ───────────────────────────────────────────────────────────────
+
+function Pagination({
+  currentPage,
+  totalPages,
+  onPageChange,
+}: {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}) {
+  if (totalPages <= 1) return null;
+
+  // Build compact page list: always show first, last, and a window around current
+  const pages: (number | "…")[] = [];
+  const window = 2;
+
+  for (let p = 1; p <= totalPages; p++) {
+    if (
+      p === 1 ||
+      p === totalPages ||
+      (p >= currentPage - window && p <= currentPage + window)
+    ) {
+      pages.push(p);
+    } else if (
+      (p === currentPage - window - 1 && p > 1) ||
+      (p === currentPage + window + 1 && p < totalPages)
+    ) {
+      pages.push("…");
+    }
+  }
+
+  return (
+    <nav
+      className="flex items-center justify-center gap-1.5 mt-8 pb-2"
+      aria-label="Pagination"
+    >
+      {/* Prev */}
+      <button
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={currentPage === 1}
+        aria-label="Previous page"
+        className="flex h-8 w-8 items-center justify-center rounded-md border text-sm font-medium text-text-muted transition-colors duration-150 hover:text-white disabled:opacity-30 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-accent"
+        style={{ borderColor: "var(--color-slate-border)" }}
+      >
+        ‹
+      </button>
+
+      {pages.map((p, i) =>
+        p === "…" ? (
+          <span key={`ellipsis-${i}`} className="px-1 text-text-muted text-sm">
+            …
+          </span>
+        ) : (
+          <PageButton
+            key={p}
+            page={p}
+            current={currentPage}
+            onClick={onPageChange}
+          />
+        ),
+      )}
+
+      {/* Next */}
+      <button
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage === totalPages}
+        aria-label="Next page"
+        className="flex h-8 w-8 items-center justify-center rounded-md border text-sm font-medium text-text-muted transition-colors duration-150 hover:text-white disabled:opacity-30 disabled:cursor-not-allowed focus-visible:ring-2 focus-visible:ring-accent"
+        style={{ borderColor: "var(--color-slate-border)" }}
+      >
+        ›
+      </button>
+    </nav>
+  );
+}
+
+// ─── Jobs Page ────────────────────────────────────────────────────────────────
+
+export default function JobsPage() {
+  // ── Filter state ───────────────────────────────────────────────────────────
+  const [keyword, setKeyword] = useState("");
+  const [debouncedKeyword, setDebouncedKeyword] = useState("");
+  const [category, setCategory] = useState("");
+  const [budgetRangeIndex, setBudgetRangeIndex] = useState<string>("");
+  const [currentPage, setCurrentPage] = useState(1);
+
+  // Refs for debounce
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Debounce keyword so we don't re-filter on every keystroke
+  useEffect(() => {
+    if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    debounceTimer.current = setTimeout(() => {
+      setDebouncedKeyword(keyword);
+      setCurrentPage(1);
+    }, 300);
+    return () => {
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    };
+  }, [keyword]);
+
+  // ── Data fetching ──────────────────────────────────────────────────────────
+  const {
+    data: allJobs,
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery<Job[]>({
+    queryKey: ["jobs", "open"],
+    queryFn: () => fetchJobs({ status: "OPEN" }),
+    // Surface errors via toast
+    meta: { onError: () => toast.error("Failed to load jobs. Please retry.") },
+  });
+
+  // ── Derived state ──────────────────────────────────────────────────────────
+  const selectedBudget: BudgetRange | null =
+    budgetRangeIndex !== ""
+      ? (BUDGET_RANGES[parseInt(budgetRangeIndex)] ?? null)
+      : null;
+
+  const filteredJobs: Job[] = filterJobs(allJobs ?? [], {
+    keyword: debouncedKeyword,
+    category,
+    budgetRange: selectedBudget,
+  });
+
+  const totalPages = Math.max(1, Math.ceil(filteredJobs.length / PAGE_SIZE));
+  const safePage = Math.min(currentPage, totalPages);
+  const pagedJobs = filteredJobs.slice(
+    (safePage - 1) * PAGE_SIZE,
+    safePage * PAGE_SIZE,
+  );
+
+  const isFiltered =
+    debouncedKeyword !== "" || category !== "" || budgetRangeIndex !== "";
+
+  // ── Handlers ──────────────────────────────────────────────────────────────
+  const clearFilters = useCallback(() => {
+    setKeyword("");
+    setDebouncedKeyword("");
+    setCategory("");
+    setBudgetRangeIndex("");
+    setCurrentPage(1);
+  }, []);
+
+  const handlePageChange = useCallback(
+    (page: number) => {
+      setCurrentPage(page);
+      // Scroll back to top of results on page change
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    },
+    [],
+  );
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6 sm:py-8">
+      {/* ── Page header ──────────────────────────────────────────────────── */}
+      <div className="mb-6">
+        <h1
+          className="text-2xl sm:text-3xl font-semibold text-white mb-1"
+          style={{ fontFamily: "var(--font-space-grotesk)" }}
+        >
+          Browse Jobs
+        </h1>
+        <p className="text-sm text-text-muted">
+          {isLoading
+            ? "Loading available jobs…"
+            : allJobs
+              ? `${filteredJobs.length} open job${filteredJobs.length !== 1 ? "s" : ""}${isFiltered ? " matching your filters" : " available"}`
+              : "Find your next project on Stellance"}
+        </p>
+      </div>
+
+      {/* ── Search + filters bar ──────────────────────────────────────────── */}
+      <div
+        className="card-surface p-4 sm:p-5 mb-6 flex flex-col sm:flex-row gap-4 items-end"
+        role="search"
+        aria-label="Job search and filters"
+      >
+        {/* Keyword search */}
+        <div className="flex-1 min-w-0 flex flex-col gap-1 w-full">
+          <label
+            htmlFor="job-search"
+            className="text-xs font-medium text-text-muted"
+          >
+            Search
+          </label>
+          <div className="relative">
+            <span
+              className="absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none text-text-muted"
+              aria-hidden
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="15"
+                height="15"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <circle cx="11" cy="11" r="8" />
+                <line x1="21" y1="21" x2="16.65" y2="16.65" />
+              </svg>
+            </span>
+            <input
+              id="job-search"
+              type="search"
+              value={keyword}
+              onChange={(e) => setKeyword(e.target.value)}
+              placeholder="Search by title, description, or skill…"
+              aria-label="Search jobs"
+              className="w-full rounded-md border bg-navy-mid pl-9 pr-3.5 py-2 text-sm text-text-primary placeholder:text-text-muted/60 transition-colors duration-150 outline-none focus:border-accent focus:ring-1 focus:ring-accent"
+              style={{ borderColor: "var(--color-slate-border)" }}
+            />
+          </div>
+        </div>
+
+        {/* Category filter */}
+        <div className="w-full sm:w-44">
+          <FilterSelect
+            id="job-category"
+            label="Category"
+            value={category}
+            onChange={(v) => { setCategory(v); setCurrentPage(1); }}
+          >
+            <option value="">All categories</option>
+            {JOB_CATEGORIES.map((cat) => (
+              <option key={cat} value={cat}>
+                {cat}
+              </option>
+            ))}
+          </FilterSelect>
+        </div>
+
+        {/* Budget filter */}
+        <div className="w-full sm:w-44">
+          <FilterSelect
+            id="job-budget"
+            label="Budget"
+            value={budgetRangeIndex}
+            onChange={(v) => { setBudgetRangeIndex(v); setCurrentPage(1); }}
+          >
+            <option value="">Any budget</option>
+            {BUDGET_RANGES.map((range, i) => (
+              <option key={range.label} value={i}>
+                {range.label}
+              </option>
+            ))}
+          </FilterSelect>
+        </div>
+
+        {/* Clear filters button — only shown when filters are active */}
+        {isFiltered && (
+          <button
+            onClick={clearFilters}
+            className="shrink-0 flex items-center gap-1.5 px-3 py-2 rounded-md text-sm font-medium text-text-muted hover:text-white border transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-accent"
+            style={{ borderColor: "var(--color-slate-border)" }}
+            aria-label="Clear all filters"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+            Clear
+          </button>
+        )}
+      </div>
+
+      {/* ── Active filter chips ───────────────────────────────────────────── */}
+      {isFiltered && (
+        <div
+          className="flex flex-wrap gap-2 mb-4"
+          aria-label="Active filters"
+        >
+          {debouncedKeyword && (
+            <FilterChip
+              label={`"${debouncedKeyword}"`}
+              onRemove={() => {
+                setKeyword("");
+                setDebouncedKeyword("");
+              }}
+            />
+          )}
+          {category && (
+            <FilterChip
+              label={category}
+              onRemove={() => setCategory("")}
+            />
+          )}
+          {selectedBudget && (
+            <FilterChip
+              label={selectedBudget.label}
+              onRemove={() => setBudgetRangeIndex("")}
+            />
+          )}
+        </div>
+      )}
+
+      {/* ── Content area ──────────────────────────────────────────────────── */}
+      {isLoading ? (
+        <LoadingGrid />
+      ) : isError ? (
+        <ErrorState onRetry={refetch} />
+      ) : pagedJobs.length === 0 ? (
+        <EmptyState filtered={isFiltered} onClear={clearFilters} />
+      ) : (
+        <>
+          <div
+            className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"
+            role="list"
+            aria-label="Job listings"
+          >
+            {pagedJobs.map((job) => (
+              <div key={job.id} role="listitem">
+                <JobCard job={job} />
+              </div>
+            ))}
+          </div>
+
+          <Pagination
+            currentPage={safePage}
+            totalPages={totalPages}
+            onPageChange={handlePageChange}
+          />
+
+          {/* Result count footer */}
+          <p className="text-center text-xs text-text-muted mt-3">
+            Showing {(safePage - 1) * PAGE_SIZE + 1}–
+            {Math.min(safePage * PAGE_SIZE, filteredJobs.length)} of{" "}
+            {filteredJobs.length} job{filteredJobs.length !== 1 ? "s" : ""}
+          </p>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── Filter chip ──────────────────────────────────────────────────────────────
+
+function FilterChip({
+  label,
+  onRemove,
+}: {
+  label: string;
+  onRemove: () => void;
+}) {
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium"
+      style={{
+        background: "rgba(61,169,252,0.1)",
+        color: "#3da9fc",
+        border: "1px solid rgba(61,169,252,0.2)",
+      }}
+    >
+      {label}
+      <button
+        onClick={onRemove}
+        aria-label={`Remove filter: ${label}`}
+        className="ml-0.5 hover:text-white transition-colors rounded-full focus-visible:ring-1 focus-visible:ring-accent"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="11"
+          height="11"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden
+        >
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
+    </span>
+  );
+}

--- a/stellance/frontend/app/(dashboard)/layout.tsx
+++ b/stellance/frontend/app/(dashboard)/layout.tsx
@@ -1,0 +1,212 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import Image from "next/image";
+
+export const metadata: Metadata = {
+  title: {
+    default: "Dashboard",
+    template: "%s | Stellance",
+  },
+};
+
+// ─── Nav items ────────────────────────────────────────────────────────────────
+
+const NAV_ITEMS = [
+  {
+    href: "/jobs",
+    label: "Browse Jobs",
+    icon: (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden
+      >
+        <rect x="2" y="7" width="20" height="14" rx="2" ry="2" />
+        <path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2" />
+      </svg>
+    ),
+  },
+  {
+    href: "/dashboard/contracts",
+    label: "My Contracts",
+    icon: (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden
+      >
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+        <polyline points="14 2 14 8 20 8" />
+        <line x1="16" y1="13" x2="8" y2="13" />
+        <line x1="16" y1="17" x2="8" y2="17" />
+        <polyline points="10 9 9 9 8 9" />
+      </svg>
+    ),
+  },
+  {
+    href: "/dashboard/payments",
+    label: "Payments",
+    icon: (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden
+      >
+        <rect x="1" y="4" width="22" height="16" rx="2" ry="2" />
+        <line x1="1" y1="10" x2="23" y2="10" />
+      </svg>
+    ),
+  },
+];
+
+// ─── Sidebar ──────────────────────────────────────────────────────────────────
+
+function Sidebar() {
+  return (
+    <aside
+      className="hidden md:flex flex-col w-56 shrink-0"
+      style={{
+        background: "var(--color-slate-panel)",
+        borderRight: "1px solid var(--color-slate-border)",
+        minHeight: "100dvh",
+      }}
+      aria-label="Main navigation"
+    >
+      {/* Logo */}
+      <div
+        className="flex items-center gap-2.5 px-5 h-14 shrink-0"
+        style={{ borderBottom: "1px solid var(--color-slate-border)" }}
+      >
+        <Image
+          src="/logo.png"
+          alt="Stellance"
+          width={26}
+          height={26}
+          style={{ borderRadius: "6px" }}
+        />
+        <span
+          className="font-semibold text-white tracking-tight"
+          style={{ fontFamily: "var(--font-space-grotesk)", fontSize: "1rem" }}
+        >
+          Stellance
+        </span>
+      </div>
+
+      {/* Nav links */}
+      <nav className="flex-1 px-3 py-4 space-y-0.5">
+        {NAV_ITEMS.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className="flex items-center gap-3 px-3 py-2.5 rounded-md text-sm font-medium text-text-muted hover:text-white hover:bg-white/5 transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1 focus-visible:ring-offset-slate-panel"
+          >
+            <span className="shrink-0">{item.icon}</span>
+            {item.label}
+          </Link>
+        ))}
+      </nav>
+
+      {/* Footer: wallet / profile placeholder */}
+      <div
+        className="px-5 py-4 shrink-0"
+        style={{ borderTop: "1px solid var(--color-slate-border)" }}
+      >
+        <div className="flex items-center gap-2.5">
+          <div
+            className="w-7 h-7 rounded-full shrink-0 flex items-center justify-center text-xs font-bold text-white"
+            style={{ background: "linear-gradient(135deg, #3da9fc, #5ee7ff)" }}
+            aria-hidden
+          >
+            S
+          </div>
+          <div className="min-w-0">
+            <p className="text-xs font-medium text-white truncate">My Account</p>
+            <p className="text-xs text-text-muted truncate">Freighter not connected</p>
+          </div>
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+// ─── Mobile top bar ───────────────────────────────────────────────────────────
+
+function TopBar() {
+  return (
+    <header
+      className="md:hidden flex items-center justify-between px-4 h-14 shrink-0"
+      style={{
+        background: "var(--color-slate-panel)",
+        borderBottom: "1px solid var(--color-slate-border)",
+        position: "sticky",
+        top: 0,
+        zIndex: 40,
+      }}
+    >
+      <Link href="/" className="flex items-center gap-2">
+        <Image src="/logo.png" alt="Stellance" width={24} height={24} style={{ borderRadius: "5px" }} />
+        <span
+          className="font-semibold text-white text-sm"
+          style={{ fontFamily: "var(--font-space-grotesk)" }}
+        >
+          Stellance
+        </span>
+      </Link>
+
+      {/* Mobile nav — simple horizontal scroll row */}
+      <nav className="flex items-center gap-1" aria-label="Mobile navigation">
+        {NAV_ITEMS.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-xs font-medium text-text-muted hover:text-white hover:bg-white/5 transition-colors"
+            aria-label={item.label}
+          >
+            {item.icon}
+            <span className="hidden sm:inline">{item.label}</span>
+          </Link>
+        ))}
+      </nav>
+    </header>
+  );
+}
+
+// ─── Layout ───────────────────────────────────────────────────────────────────
+
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-h-dvh bg-navy">
+      <Sidebar />
+
+      <div className="flex flex-col flex-1 min-w-0">
+        <TopBar />
+        <main className="flex-1 overflow-y-auto">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/stellance/frontend/components/jobs/JobCard.tsx
+++ b/stellance/frontend/components/jobs/JobCard.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import Link from "next/link";
+import type { Job } from "@/lib/api/jobs";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Format a Prisma Decimal string as a human-readable USD amount. */
+function formatBudget(budget: string): string {
+  const n = parseFloat(budget);
+  if (isNaN(n)) return budget;
+
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(1)}k`;
+  return `$${n.toLocaleString("en-US", { maximumFractionDigits: 2 })}`;
+}
+
+/** Return a human-readable relative timestamp (e.g. "3 days ago"). */
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60_000);
+  const hours = Math.floor(mins / 60);
+  const days = Math.floor(hours / 24);
+
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  if (hours < 24) return `${hours}h ago`;
+  if (days < 30) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/** Colour map for job status badges. */
+const STATUS_STYLES: Record<
+  Job["status"],
+  { bg: string; text: string; dot: string }
+> = {
+  OPEN: {
+    bg: "rgba(45,212,191,0.12)",
+    text: "#2dd4bf",
+    dot: "#2dd4bf",
+  },
+  IN_PROGRESS: {
+    bg: "rgba(61,169,252,0.12)",
+    text: "#3da9fc",
+    dot: "#3da9fc",
+  },
+  COMPLETED: {
+    bg: "rgba(100,116,139,0.15)",
+    text: "#94a3b8",
+    dot: "#94a3b8",
+  },
+  CANCELLED: {
+    bg: "rgba(248,113,113,0.12)",
+    text: "#f87171",
+    dot: "#f87171",
+  },
+};
+
+const STATUS_LABEL: Record<Job["status"], string> = {
+  OPEN: "Open",
+  IN_PROGRESS: "In Progress",
+  COMPLETED: "Completed",
+  CANCELLED: "Cancelled",
+};
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface JobCardProps {
+  job: Job;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+/**
+ * JobCard
+ *
+ * Displays a single job listing in a card format. Links to the job detail page.
+ * Uses the existing design tokens (card-surface, glow-accent, gradient-text, etc.)
+ * from globals.css.
+ */
+export default function JobCard({ job }: JobCardProps) {
+  const statusStyle = STATUS_STYLES[job.status];
+  const budget = formatBudget(job.budget);
+  const posted = timeAgo(job.createdAt);
+
+  return (
+    <Link
+      href={`/jobs/${job.id}`}
+      className="group block card-surface p-5 sm:p-6 transition-all duration-200 hover:border-accent/40 hover:shadow-[0_4px_32px_rgba(61,169,252,0.12)] focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-navy"
+      aria-label={`View job: ${job.title}`}
+    >
+      {/* ── Header row ─────────────────────────────────────────────────────── */}
+      <div className="flex items-start justify-between gap-3 mb-3">
+        {/* Category chip */}
+        <span
+          className="inline-flex items-center shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium"
+          style={{
+            background: "rgba(61,169,252,0.1)",
+            color: "#3da9fc",
+            border: "1px solid rgba(61,169,252,0.2)",
+          }}
+        >
+          {job.category}
+        </span>
+
+        {/* Status badge */}
+        <span
+          className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium shrink-0"
+          style={{
+            background: statusStyle.bg,
+            color: statusStyle.text,
+          }}
+          aria-label={`Status: ${STATUS_LABEL[job.status]}`}
+        >
+          <span
+            aria-hidden
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: "50%",
+              backgroundColor: statusStyle.dot,
+              display: "inline-block",
+              flexShrink: 0,
+            }}
+          />
+          {STATUS_LABEL[job.status]}
+        </span>
+      </div>
+
+      {/* ── Title ──────────────────────────────────────────────────────────── */}
+      <h3 className="text-base font-semibold text-white mb-2 line-clamp-2 group-hover:text-accent transition-colors duration-150 font-heading">
+        {job.title}
+      </h3>
+
+      {/* ── Description ────────────────────────────────────────────────────── */}
+      <p className="text-sm text-text-muted line-clamp-3 mb-4 leading-relaxed">
+        {job.description}
+      </p>
+
+      {/* ── Footer row ─────────────────────────────────────────────────────── */}
+      <div
+        className="flex items-center justify-between gap-2 pt-4"
+        style={{ borderTop: "1px solid rgba(36,53,84,0.8)" }}
+      >
+        {/* Budget */}
+        <div className="flex items-center gap-1.5">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="text-success shrink-0"
+            aria-hidden
+          >
+            <circle cx="12" cy="12" r="10" />
+            <path d="M12 6v12M9 9h4.5a2.5 2.5 0 0 1 0 5H9" />
+          </svg>
+          <span className="text-sm font-semibold text-success">{budget}</span>
+        </div>
+
+        {/* Right side: client name + posted time */}
+        <div className="flex items-center gap-3 min-w-0">
+          {/* Client name */}
+          {job.client?.name && (
+            <span className="text-xs text-text-muted truncate max-w-[120px]">
+              {job.client.name}
+            </span>
+          )}
+
+          {/* Time separator dot */}
+          <span aria-hidden className="text-slate-border text-xs">·</span>
+
+          {/* Posted time */}
+          <time
+            dateTime={job.createdAt}
+            className="text-xs text-text-muted whitespace-nowrap"
+          >
+            {posted}
+          </time>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+// ─── Skeleton ─────────────────────────────────────────────────────────────────
+
+/**
+ * JobCardSkeleton
+ *
+ * Loading placeholder that mirrors the layout of JobCard. Animated pulse
+ * provides a clear visual "loading" signal without layout shift.
+ */
+export function JobCardSkeleton() {
+  return (
+    <div
+      className="card-surface p-5 sm:p-6 animate-pulse"
+      aria-hidden
+      role="presentation"
+    >
+      {/* Header row */}
+      <div className="flex items-center justify-between mb-3">
+        <div
+          className="h-5 rounded-full w-24"
+          style={{ background: "rgba(36,53,84,0.8)" }}
+        />
+        <div
+          className="h-5 rounded-full w-20"
+          style={{ background: "rgba(36,53,84,0.8)" }}
+        />
+      </div>
+
+      {/* Title */}
+      <div
+        className="h-5 rounded w-4/5 mb-2"
+        style={{ background: "rgba(36,53,84,0.8)" }}
+      />
+      <div
+        className="h-5 rounded w-3/5 mb-4"
+        style={{ background: "rgba(36,53,84,0.6)" }}
+      />
+
+      {/* Description */}
+      <div className="space-y-1.5 mb-4">
+        <div
+          className="h-3.5 rounded w-full"
+          style={{ background: "rgba(36,53,84,0.6)" }}
+        />
+        <div
+          className="h-3.5 rounded w-full"
+          style={{ background: "rgba(36,53,84,0.6)" }}
+        />
+        <div
+          className="h-3.5 rounded w-2/3"
+          style={{ background: "rgba(36,53,84,0.5)" }}
+        />
+      </div>
+
+      {/* Footer */}
+      <div
+        className="flex items-center justify-between pt-4"
+        style={{ borderTop: "1px solid rgba(36,53,84,0.8)" }}
+      >
+        <div
+          className="h-4 rounded w-16"
+          style={{ background: "rgba(36,53,84,0.7)" }}
+        />
+        <div
+          className="h-3 rounded w-24"
+          style={{ background: "rgba(36,53,84,0.6)" }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/stellance/frontend/lib/api/jobs.ts
+++ b/stellance/frontend/lib/api/jobs.ts
@@ -1,0 +1,189 @@
+/**
+ * API client for the /jobs endpoints.
+ *
+ * Thin wrappers around fetch. All functions read the access_token from
+ * sessionStorage so they can be called from client components without
+ * prop-drilling the token.
+ */
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001/api";
+
+// ─── Enums (mirrored from Prisma schema) ─────────────────────────────────────
+
+export type JobStatus = "OPEN" | "IN_PROGRESS" | "COMPLETED" | "CANCELLED";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface JobClient {
+  id: string;
+  name: string;
+  stellarPublicKey: string | null;
+}
+
+export interface JobContract {
+  id: string;
+  status: string;
+}
+
+export interface Job {
+  id: string;
+  title: string;
+  description: string;
+  /** Prisma Decimal is serialised as a string over JSON */
+  budget: string;
+  category: string;
+  status: JobStatus;
+  clientId: string;
+  createdAt: string;
+  updatedAt: string;
+  client: JobClient;
+  contract: JobContract | null;
+}
+
+export interface JobsQueryParams {
+  status?: JobStatus;
+  /** When true, only return the current user's jobs */
+  mine?: boolean;
+}
+
+// ─── Error class ──────────────────────────────────────────────────────────────
+
+export class JobsApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "JobsApiError";
+  }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getAuthHeaders(): HeadersInit {
+  const token =
+    typeof window !== "undefined"
+      ? sessionStorage.getItem("access_token")
+      : null;
+
+  return {
+    "Content-Type": "application/json",
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+async function apiFetch<T>(path: string): Promise<T> {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method: "GET",
+    credentials: "include",
+    headers: getAuthHeaders(),
+  });
+
+  if (!res.ok) {
+    let message = res.statusText || "An unexpected error occurred.";
+    try {
+      const body = (await res.json()) as { message?: string | string[] };
+      if (body.message) {
+        message = Array.isArray(body.message)
+          ? body.message.join(", ")
+          : body.message;
+      }
+    } catch {
+      // non-JSON error body — use statusText
+    }
+    throw new JobsApiError(res.status, message);
+  }
+
+  return res.json() as Promise<T>;
+}
+
+// ─── Jobs API ─────────────────────────────────────────────────────────────────
+
+/**
+ * Fetch all jobs from GET /jobs.
+ * Passes optional status and mine filters as query params.
+ */
+export async function fetchJobs(params?: JobsQueryParams): Promise<Job[]> {
+  const qs = new URLSearchParams();
+  if (params?.status) qs.set("status", params.status);
+  if (params?.mine) qs.set("mine", "true");
+
+  const query = qs.toString() ? `?${qs.toString()}` : "";
+  return apiFetch<Job[]>(`/jobs${query}`);
+}
+
+/**
+ * Fetch a single job by id.
+ */
+export async function fetchJob(id: string): Promise<Job> {
+  return apiFetch<Job>(`/jobs/${id}`);
+}
+
+// ─── Client-side derived helpers ──────────────────────────────────────────────
+
+/** Available job categories derived from real data (can be expanded over time). */
+export const JOB_CATEGORIES = [
+  "Smart Contracts",
+  "Frontend",
+  "Backend",
+  "Mobile",
+  "Design",
+  "DevOps",
+  "Writing",
+  "Marketing",
+  "Data Science",
+  "Other",
+] as const;
+
+export type JobCategory = (typeof JOB_CATEGORIES)[number];
+
+export interface BudgetRange {
+  label: string;
+  min: number;
+  max: number | null;
+}
+
+export const BUDGET_RANGES: BudgetRange[] = [
+  { label: "Under $500", min: 0, max: 500 },
+  { label: "$500 – $1,000", min: 500, max: 1000 },
+  { label: "$1,000 – $5,000", min: 1000, max: 5000 },
+  { label: "$5,000 – $10,000", min: 5000, max: 10000 },
+  { label: "$10,000+", min: 10000, max: null },
+];
+
+/**
+ * Apply keyword, category, and budget filters entirely on the client.
+ * The backend only supports status + mine filters, so finer filtering is done
+ * after the initial fetch.
+ */
+export function filterJobs(
+  jobs: Job[],
+  opts: {
+    keyword: string;
+    category: string;
+    budgetRange: BudgetRange | null;
+  },
+): Job[] {
+  const kw = opts.keyword.toLowerCase().trim();
+
+  return jobs.filter((job) => {
+    // Keyword match against title, description, or category
+    if (kw) {
+      const haystack = `${job.title} ${job.description} ${job.category}`.toLowerCase();
+      if (!haystack.includes(kw)) return false;
+    }
+
+    // Category filter
+    if (opts.category && job.category !== opts.category) return false;
+
+    // Budget filter
+    if (opts.budgetRange) {
+      const budget = parseFloat(job.budget);
+      if (budget < opts.budgetRange.min) return false;
+      if (opts.budgetRange.max !== null && budget > opts.budgetRange.max)
+        return false;
+    }
+
+    return true;
+  });
+}


### PR DESCRIPTION
## Summary

Implements the jobs browsing page where freelancers can discover and filter open jobs posted by clients. This is a purely frontend feature that integrates with the existing `GET /jobs` API.

---

## Files Changed

| File | Description |
|------|-------------|
| `stellance/frontend/lib/api/jobs.ts` | Jobs API client and shared types |
| `stellance/frontend/components/jobs/JobCard.tsx` | Reusable job card + skeleton component |
| `stellance/frontend/app/(dashboard)/layout.tsx` | Dashboard shell (sidebar + mobile nav) |
| `stellance/frontend/app/(dashboard)/jobs/page.tsx` | Jobs browsing page |

---

## Features Implemented

### Data fetching
- `useQuery` (TanStack Query) calls `GET /jobs?status=OPEN`
- Leverages the existing `QueryProvider` stale/gcTime settings
- Bearer token read from `sessionStorage` (same pattern as auth)

### Search bar
- Debounced keyword input (300 ms) — filters against job title, description, and category
- Resets pagination to page 1 on new input

### Filters
- **Category** — select from 10 predefined categories matching backend data
- **Budget range** — 5 ranges (Under $500 → $10k+), client-side comparison against the Prisma `Decimal` string
- Both filters reset page to 1 on change
- Active filters rendered as dismissible chips below the filter bar
- "Clear all" button appears when any filter is active

### Loading skeleton state
- 12 `JobCardSkeleton` placeholders animate with `pulse` while data is in flight
- ARIA `role="status"` + `aria-label` for screen reader announcement

### Empty state
- Two variants: no open jobs at all vs. no matches for current filters
- Filter-match variant includes a "Clear all filters" CTA

### Error state
- Surfaces fetch failures with a retry button wired to `refetch()`
- Toast notification on query error via `sonner`

### Pagination
- Page-based, 12 jobs per page
- Compact page number list with ellipsis for large page counts
- Prev/Next buttons; disabled at boundaries
- "Showing X–Y of Z jobs" result count footer
- Scrolls to top on page change

### JobCard component
- Category chip + colour-coded status badge (OPEN / IN_PROGRESS / COMPLETED / CANCELLED)
- Budget formatted as $Xk / $XM for large values
- Relative timestamp ("3d ago", "just now")
- Client name display
- 3-line description clamp
- Hover glow + accent title transition
- Full keyboard focus-visible ring
- Links to `/jobs/:id` (detail page, to be implemented separately)

### Dashboard layout
- Desktop: persistent sidebar (logo, nav links, account footer placeholder)
- Mobile: sticky top bar with icon + label nav
- Nav items: Browse Jobs · My Contracts · Payments

---

## What Was Tested
- `tsc --noEmit` — 0 errors
- `eslint` — 0 errors, 0 warnings
- Filter logic manually traced: keyword debounce, category match, budget range comparison, page reset on filter change

## Out of Scope / Follow-up
- `/jobs/:id` detail page (JobCard links are ready, page not yet created)
- Freighter wallet connection in the sidebar account footer
- `POST /jobs` create-job flow (client role)
- `?mine=true` view for clients to see their own postings

closes #5 
