### PR TITLE
feat(frontend): add Stellar wallet connection via Freighter

### DIFF
--- a/stellance/backend/package-lock.json
+++ b/stellance/backend/package-lock.json
@@ -16,8 +16,8 @@
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/swagger": "^11.2.6",
-        "@prisma/adapter-pg": "^7.9.0",
-        "@prisma/client": "^7.9.0",
+        "@prisma/adapter-pg": "7.8.0",
+        "@prisma/client": "7.8.0",
         "@stellar/stellar-sdk": "^13.3.0",
         "argon2": "^0.44.0",
         "class-transformer": "^0.5.1",
@@ -55,7 +55,7 @@
         "globals": "^16.0.0",
         "jest": "^30.0.0",
         "prettier": "^3.4.2",
-        "prisma": "^7.9.0",
+        "prisma": "7.8.0",
         "source-map-support": "^0.5.21",
         "supertest": "^7.0.0",
         "ts-jest": "^29.2.5",
@@ -772,33 +772,33 @@
       }
     },
     "node_modules/@electric-sql/pglite": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.3.tgz",
-      "integrity": "sha512-ichuWTgtd4mOM1G4SpyGJa5trT03lWbMypDV0fUXUCXg5hiHqVAz/bZyV68NqmkLB7WcYmj1RMJVSp8HV/v/ZQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.1.tgz",
+      "integrity": "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite-socket": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.1.3.tgz",
-      "integrity": "sha512-LAciWM0M1dCL8hlsxu2venbVZcdxema0BtDfpWYVqr+Y468UADw0pFWidhKw1M8sfJ8rdLT71tjMmnirf/IZRQ==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.1.1.tgz",
+      "integrity": "sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "pglite-server": "dist/scripts/server.js"
       },
       "peerDependencies": {
-        "@electric-sql/pglite": "0.4.3"
+        "@electric-sql/pglite": "0.4.1"
       }
     },
     "node_modules/@electric-sql/pglite-tools": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.3.3.tgz",
-      "integrity": "sha512-AlzLJTRJ8+UFgK8CmxIpyIpJ0+YaFw02IiOSdYrqxwPXdSyeIShz8aa9Tq+tYFXdPwcaMp/Fc80mQZ1dkOQ/wg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.3.1.tgz",
+      "integrity": "sha512-C+T3oivmy9bpQvSxVqXA1UDY8cB9Eb9vZHL9zxWwEUfDixbXv4G3r2LjoTdR33LD8aomR3O9ZXEO3XEwr/cUCA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@electric-sql/pglite": "0.4.3"
+        "@electric-sql/pglite": "0.4.1"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1043,6 +1043,19 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2155,6 +2168,13 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
@@ -2778,24 +2798,24 @@
       }
     },
     "node_modules/@prisma/adapter-pg": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/adapter-pg/-/adapter-pg-7.9.0.tgz",
-      "integrity": "sha512-kPYuFvNTlqnaFf2UpXBBG3ycTT3PL76uSZtLFBEwDytjMMUW8ZHrsb9cSNIarzdPW5EXWmBOeOq9/MVjMtbWkA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/adapter-pg/-/adapter-pg-7.8.0.tgz",
+      "integrity": "sha512-ygb3UkerK3v8MDpXVgCISdRNDozpxh6+JVJgiIGbSr5KBgz10LLf5ejUskPGoXlsIjxsOu6nuy1JVQr2EKGSlg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/driver-adapter-utils": "7.9.0",
+        "@prisma/driver-adapter-utils": "7.8.0",
         "@types/pg": "^8.16.0",
         "pg": "^8.16.3",
         "postgres-array": "3.0.4"
       }
     },
     "node_modules/@prisma/client": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.9.0.tgz",
-      "integrity": "sha512-BTG/mB+WL/1sD2gWwdNc2uuVJjNNBgCDlPFdjco6jJArgbg4IAChtzVeW4debFa/NKBbsGedCjET316sjllWTQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.8.0.tgz",
+      "integrity": "sha512-HFp3Dawv/3sU3JtlPha90IB+48lS7zHiH4LKZPjmcE8YH5P9DOXGPvo8dqOtO7MqLDd1p2hOWMcFlRT1DMblHw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/client-runtime-utils": "7.9.0"
+        "@prisma/client-runtime-utils": "7.8.0"
       },
       "engines": {
         "node": "^20.19 || ^22.12 || >=24.0"
@@ -2814,15 +2834,15 @@
       }
     },
     "node_modules/@prisma/client-runtime-utils": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client-runtime-utils/-/client-runtime-utils-7.9.0.tgz",
-      "integrity": "sha512-kMVmS4ZEy3xlkca+TfxOEm/ToVVlOS2x1Tc6/wIRf/HfczBqENtSPcKszy4ZpFNzjJ8SRKvlU5V0rrpoFw2KOg==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client-runtime-utils/-/client-runtime-utils-7.8.0.tgz",
+      "integrity": "sha512-5NQZztQ0oY/ADFkmd9gPuweH5A1/CCY8YQPorLLO0Mu6a87mY5gsnDkzmFmIHs9NFaLnZojzgddFVN4RpKYrdw==",
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/config": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.9.0.tgz",
-      "integrity": "sha512-CsoK2mhl0u+N4/8V+XroQMOUNIic4isqD+E2HBG8l1yGEKo62CFDu3FHo0FdwItjl6XkW+omA1STSzeN1DAXlg==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.8.0.tgz",
+      "integrity": "sha512-HFESzd9rx2ZQxlK+TL7tu1HPvCqrHiL6LCxYykI2c34mvaUuIVVl3lYuicJD/MNnzgPnyeBEMlK4WTomJCV5jw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2833,27 +2853,29 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.9.0.tgz",
-      "integrity": "sha512-i0KdVQuKUE6N9NloHs+sUNAk2c9svR3myBndQbA3BoeoArsSpwtNgTdHZL+wBtCLCcdS2OOC/PKhgTe36jkF5A==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.8.0.tgz",
+      "integrity": "sha512-p+QZReysDUqXC+mk17q9a+Y/qzh4c2KYliDK30buYUyfrGeTGSyfmc0AIrJRhZJrLHhRiJa9Au/J72h3C+szvA==",
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/dev": {
-      "version": "0.24.14",
-      "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.24.14.tgz",
-      "integrity": "sha512-NhFO49O2JPTdzYiLHvceQn/HiwmcKF/iGV39ko3CpYsoGqS3rz3ko6gzuxFSIeHNwNJeuNcDexyyGeTO3DW80A==",
+      "version": "0.24.3",
+      "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.24.3.tgz",
+      "integrity": "sha512-ffHlQuKXZiaDt9Go0OnCTdJZrHxK0k7omJKNV86/VjpsXu5EIHZLK0T7JSWgvNlJwh56kW9JFu9v0qJciFzepg==",
       "devOptional": true,
       "license": "ISC",
       "dependencies": {
-        "@electric-sql/pglite": "0.4.3",
-        "@electric-sql/pglite-socket": "0.1.3",
-        "@electric-sql/pglite-tools": "0.3.3",
+        "@electric-sql/pglite": "0.4.1",
+        "@electric-sql/pglite-socket": "0.1.1",
+        "@electric-sql/pglite-tools": "0.3.1",
+        "@hono/node-server": "1.19.11",
         "@prisma/get-platform": "7.2.0",
         "@prisma/query-plan-executor": "7.2.0",
-        "@prisma/streams-local": "0.1.11",
-        "find-my-way": "9.6.0",
+        "@prisma/streams-local": "0.1.2",
         "foreground-child": "3.3.1",
         "get-port-please": "3.2.0",
+        "hono": "^4.12.8",
+        "http-status-codes": "2.3.0",
         "pathe": "2.0.3",
         "proper-lockfile": "4.1.2",
         "remeda": "2.33.4",
@@ -2863,65 +2885,65 @@
       }
     },
     "node_modules/@prisma/driver-adapter-utils": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-7.9.0.tgz",
-      "integrity": "sha512-fFXujitfMyjk3kOd1Tbs5FXBm6i2OWwEhaP5lHgkUM99jHpPEQwCWj+z/WKPFq6EDMThE1zGzSlVegtR0Pmu2w==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/driver-adapter-utils/-/driver-adapter-utils-7.8.0.tgz",
+      "integrity": "sha512-/Q13o0ZT0rjc1Xk0Q9KhZYwuq2EW/vSbWUBKfgEKkaCuB/Sg6bqnjmTZqC5cD4d6y1vfFAEwBRzfzoSMIVJ55A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.9.0"
+        "@prisma/debug": "7.8.0"
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.9.0.tgz",
-      "integrity": "sha512-lDWJp/pgSWCLfYsupmmNo96jfsbQnH1yjia8XVM2Kh8nRZhD0bQU2jCHuy3ZTPMLR3apRD3k145ybENalAYjYw==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.8.0.tgz",
+      "integrity": "sha512-jx3rCnNNrt5uzbkKlegtQ2GZHxSlihMCzutgT/BP6UIDF1r9tDI39hV/0T/cHZgzJ3ELbuQPXlVZy+Y1n0pcgw==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.9.0",
-        "@prisma/engines-version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
-        "@prisma/fetch-engine": "7.9.0",
-        "@prisma/get-platform": "7.9.0"
+        "@prisma/debug": "7.8.0",
+        "@prisma/engines-version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a",
+        "@prisma/fetch-engine": "7.8.0",
+        "@prisma/get-platform": "7.8.0"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad.tgz",
-      "integrity": "sha512-2BsPPFksz3CQUXG6af3rVCtJKg6+JJGJTtfgu2fU8DdXhOfkBjulCq8mwybCd6ge0/jhZq2kOtLAbmUDMyI1nA==",
+      "version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a.tgz",
+      "integrity": "sha512-fJPQxCkLgA5EayWaW8eArgCvjJ+N+Kz3VyeNKMEeYiQC4alNkxRKFVAGxv/ZUzuJISKqdw+zGeDbS6mn6RCPOA==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.9.0.tgz",
-      "integrity": "sha512-4awv6ATdgrHdLms0XKikCyfArn8BrUHZfqg0mtCKrI4+WJe24nmpsdwsypM9ozd03wa846AngY+zSbnngkMrXQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.8.0.tgz",
+      "integrity": "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.9.0"
+        "@prisma/debug": "7.8.0"
       }
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.9.0.tgz",
-      "integrity": "sha512-F0XlIgjbE3EywRVR/HpCerNI/dxo40vK66tHcWpsWYwH/Jk9+FsICEzATeMsZ7bdnpZz93hkD4sAb5rKLsCCpA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.8.0.tgz",
+      "integrity": "sha512-gwB0Euiz/DDRyxFRpLXYlK3RfaZUj1c5dAYMuhZYfApg7arknJlcb9bIsOHDppJmbqYaVA+yBIiFMDBfprsNPQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.9.0",
-        "@prisma/engines-version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
-        "@prisma/get-platform": "7.9.0"
+        "@prisma/debug": "7.8.0",
+        "@prisma/engines-version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a",
+        "@prisma/get-platform": "7.8.0"
       }
     },
     "node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.9.0.tgz",
-      "integrity": "sha512-4awv6ATdgrHdLms0XKikCyfArn8BrUHZfqg0mtCKrI4+WJe24nmpsdwsypM9ozd03wa846AngY+zSbnngkMrXQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.8.0.tgz",
+      "integrity": "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.9.0"
+        "@prisma/debug": "7.8.0"
       }
     },
     "node_modules/@prisma/get-platform": {
@@ -2949,9 +2971,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/streams-local": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@prisma/streams-local/-/streams-local-0.1.11.tgz",
-      "integrity": "sha512-0TcebL559MByKqTJ+SsrFIEg228iw8UCVRFckzgfRSiJqczhs+MuAgWOF9lnOIV/IVqvu+KMnFTH0eDeTQMpUg==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@prisma/streams-local/-/streams-local-0.1.2.tgz",
+      "integrity": "sha512-l49yTxKKF2odFxaAXTmwmkBKL3+bVQ1tFOooGifu4xkdb9NMNLxHj27XAhTylWZod8I+ISGM5erU1xcl/oBCtg==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2961,7 +2983,7 @@
         "proper-lockfile": "^4.1.2"
       },
       "engines": {
-        "bun": ">=1.2.0",
+        "bun": ">=1.3.6",
         "node": ">=22.0.0"
       }
     },
@@ -2990,23 +3012,14 @@
       "license": "MIT"
     },
     "node_modules/@prisma/studio-core": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.33.0.tgz",
-      "integrity": "sha512-V2fX/nKEymNTrHXwfP26PGjoLStO35Ogu+ex7CFJbLrMYEcZxxZpiSNOs7px23Hk5mzLWvM5RsqG6Ka+rha+wg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.27.3.tgz",
+      "integrity": "sha512-AADjNFPdsrglxHQVTmHFqv6DuKQZ5WY4p5/gVFY017twvNrSwpLJ9lqUbYYxEu2W7nbvVxTZA8deJ8LseNALsw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@radix-ui/react-toggle": "1.1.10",
-        "@visx/curve": "4.0.1-alpha.0",
-        "@visx/event": "4.0.1-alpha.0",
-        "@visx/grid": "4.0.1-alpha.0",
-        "@visx/group": "4.0.1-alpha.0",
-        "@visx/responsive": "4.0.1-alpha.0",
-        "@visx/scale": "4.0.1-alpha.0",
-        "@visx/shape": "4.0.1-alpha.0",
-        "d3-array": "3.2.4",
-        "d3-shape": "3.2.0",
-        "elkjs": "0.11.1"
+        "chart.js": "4.5.1"
       },
       "engines": {
         "node": "^20.19 || ^22.12 || >=24.0",
@@ -3397,95 +3410,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/d3-array": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.3.tgz",
-      "integrity": "sha512-Reoy+pKnvsksN0lQUlcH6dOGjRZ/3WRwXR//m+/8lt1BXeI4xyaUZoqULNjyXXRuh0Mj4LNpkCvhUpQlY3X5xQ==",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA==",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-delaunay": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.1.tgz",
-      "integrity": "sha512-tLxQ2sfT0p6sxdG75c6f/ekqxjyYR0+LwPrsO1mbC9YDBzPJhs2HbJJRrn8Ez1DBoHRo2yx7YEATI+8V1nGMnQ==",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-format": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.1.tgz",
-      "integrity": "sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg==",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-geo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
-      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*"
-      }
-    },
-    "node_modules/@types/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-color": "*"
-      }
-    },
-    "node_modules/@types/d3-path": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-shape": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
-      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-path": "*"
-      }
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz",
-      "integrity": "sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-time-format": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.1.0.tgz",
-      "integrity": "sha512-/myT3I7EwlukNOX2xVdMzb8FRgNzRMpsZddwst9Ld/VFe6LyJyRp0s32l/V9XoUzk+Gqu56F/oGk6507+8BxrA==",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -3546,13 +3470,6 @@
         "@types/range-parser": "*",
         "@types/send": "*"
       }
-    },
-    "node_modules/@types/geojson": {
-      "version": "7946.0.16",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
-      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-      "devOptional": true,
-      "license": "MIT"
     },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
@@ -3615,13 +3532,6 @@
         "@types/ms": "*",
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.17.24",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
-      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
-      "devOptional": true,
-      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -3720,6 +3630,7 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4181,157 +4092,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@visx/curve": {
-      "version": "4.0.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@visx/curve/-/curve-4.0.1-alpha.0.tgz",
-      "integrity": "sha512-jRu61Uz274pV1zyioXmboyrLutYbnKsgjj4njSGCnhdXj5GkZvZbg+ThDb6oOzoAnJOBRLz4rzPlWvNJOzuVMg==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@visx/vendor": "4.0.0-alpha.0"
-      }
-    },
-    "node_modules/@visx/event": {
-      "version": "4.0.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@visx/event/-/event-4.0.1-alpha.0.tgz",
-      "integrity": "sha512-EQqCMSv/s8NbFjo+hz3FKsvvYfP+2QslsFJ/24/O5l/W+7UC6J6aAvO0ujVwrTwdYbuQ+vhxKi1xdPdKR/qj1g==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/react": "*",
-        "@visx/point": "4.0.1-alpha.0"
-      }
-    },
-    "node_modules/@visx/grid": {
-      "version": "4.0.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@visx/grid/-/grid-4.0.1-alpha.0.tgz",
-      "integrity": "sha512-rycutGmTHO+znNdPumheWMglm7YfpffvRwUkVy5zy4WoORIuKTMkDxwnOzHG2xMxU3EE/YCd37xFV5AxA30yeg==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/react": "*",
-        "@visx/curve": "4.0.1-alpha.0",
-        "@visx/group": "4.0.1-alpha.0",
-        "@visx/point": "4.0.1-alpha.0",
-        "@visx/scale": "4.0.1-alpha.0",
-        "@visx/shape": "4.0.1-alpha.0",
-        "classnames": "^2.3.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
-      }
-    },
-    "node_modules/@visx/group": {
-      "version": "4.0.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@visx/group/-/group-4.0.1-alpha.0.tgz",
-      "integrity": "sha512-V19l7iQ7jccBv8kao/EByuI6o4xtxzzLV9nqVI1hRvmdzTVsuLpqlwzYCZUXJaTVvUWf8s4D2SQFjGkj/Nw+0w==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/react": "*",
-        "classnames": "^2.3.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
-      }
-    },
-    "node_modules/@visx/point": {
-      "version": "4.0.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@visx/point/-/point-4.0.1-alpha.0.tgz",
-      "integrity": "sha512-ijTfr/Nx09f03vIj9nyTr3z4Xth4Y75427UaogJh6dnIRLMEFHQOwNu791sbfiNj0a+ZXuaE32h0vKrFe4/8Qg==",
-      "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/@visx/responsive": {
-      "version": "4.0.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@visx/responsive/-/responsive-4.0.1-alpha.0.tgz",
-      "integrity": "sha512-o+1zGywQZY0+yOx3Iw87wc4bbPJRr/HnIukTwfOz4UVyj9pB1OQNVHB7OORO1+LBHJceWpB31co/ZV9KHncKrA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "^4.17.13",
-        "@types/react": "*",
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
-      }
-    },
-    "node_modules/@visx/scale": {
-      "version": "4.0.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@visx/scale/-/scale-4.0.1-alpha.0.tgz",
-      "integrity": "sha512-nzjeE87vFSAXGWFiiNfBpNLAf0Q8Qmf6syvKLjqNi4kGZkdhbUll3E/59YsgWXmjM8+llPLWzGsP+JPvo5eq1A==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@visx/vendor": "4.0.0-alpha.0"
-      }
-    },
-    "node_modules/@visx/shape": {
-      "version": "4.0.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@visx/shape/-/shape-4.0.1-alpha.0.tgz",
-      "integrity": "sha512-62QeiVNmPlterQGwhkEDcbq7M0MqY0lBsK5QKXtM9ZoPZWkuGV3aykA3+Xu20B2FAvyJq4LqJzBc7Sxr+EAdbA==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "^4.17.13",
-        "@types/react": "*",
-        "@visx/curve": "4.0.1-alpha.0",
-        "@visx/group": "4.0.1-alpha.0",
-        "@visx/scale": "4.0.1-alpha.0",
-        "@visx/vendor": "4.0.0-alpha.0",
-        "classnames": "^2.3.1",
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
-      }
-    },
-    "node_modules/@visx/vendor": {
-      "version": "4.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@visx/vendor/-/vendor-4.0.0-alpha.0.tgz",
-      "integrity": "sha512-6I+MuqXBcv9jnlcVowHoHKSdk9gXTWkHLKyqBwRWg7LY6A3Ei8SHfubpqGV5rBUSppxMq2RszPJUS6w+H0YgmQ==",
-      "devOptional": true,
-      "license": "MIT and ISC",
-      "dependencies": {
-        "@types/d3-array": "3.0.3",
-        "@types/d3-color": "3.1.0",
-        "@types/d3-delaunay": "6.0.1",
-        "@types/d3-format": "3.0.1",
-        "@types/d3-geo": "3.1.0",
-        "@types/d3-interpolate": "3.0.1",
-        "@types/d3-path": "3.1.1",
-        "@types/d3-scale": "4.0.2",
-        "@types/d3-shape": "3.1.7",
-        "@types/d3-time": "3.0.0",
-        "@types/d3-time-format": "2.1.0",
-        "d3-array": "3.2.1",
-        "d3-color": "3.1.0",
-        "d3-delaunay": "6.0.2",
-        "d3-format": "3.1.0",
-        "d3-geo": "3.1.0",
-        "d3-interpolate": "3.0.1",
-        "d3-path": "3.1.0",
-        "d3-scale": "4.0.2",
-        "d3-shape": "3.2.0",
-        "d3-time": "3.1.0",
-        "d3-time-format": "4.1.0",
-        "internmap": "2.0.3"
-      }
-    },
-    "node_modules/@visx/vendor/node_modules/d3-array": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.1.tgz",
-      "integrity": "sha512-gUY/qeHq/yNqqoCKNq4vtpFLdoCdvyNpWoC/KNjhGbhDuQpAM9sIQQKkXSNpXa9h5KySs/gzm7R88WkUutgwWQ==",
-      "devOptional": true,
-      "license": "ISC",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
@@ -5419,6 +5179,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -5484,13 +5257,6 @@
         "libphonenumber-js": "^1.11.1",
         "validator": "^13.15.22"
       }
-    },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "devOptional": true,
-      "license": "MIT"
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -5851,145 +5617,8 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
-      "license": "MIT"
-    },
-    "node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "devOptional": true,
-      "license": "ISC",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "devOptional": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-delaunay": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.2.tgz",
-      "integrity": "sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==",
-      "devOptional": true,
-      "license": "ISC",
-      "dependencies": {
-        "delaunator": "5"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-format": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
-      "devOptional": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-geo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
-      "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
-      "devOptional": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.5.0 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "devOptional": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "devOptional": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "devOptional": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "devOptional": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "devOptional": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "devOptional": true,
-      "license": "ISC",
-      "dependencies": {
-        "d3-time": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -6086,16 +5715,6 @@
       "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/delaunator": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
-      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
-      "devOptional": true,
-      "license": "ISC",
-      "dependencies": {
-        "robust-predicates": "^3.0.2"
-      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -6256,13 +5875,6 @@
       "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/elkjs": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.11.1.tgz",
-      "integrity": "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==",
-      "devOptional": true,
-      "license": "EPL-2.0"
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -6893,13 +6505,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/fast-decode-uri-component": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
-      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
-      "devOptional": true,
-      "license": "MIT"
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6927,16 +6532,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-querystring": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
-      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-decode-uri-component": "^1.0.1"
-      }
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
@@ -7048,21 +6643,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/find-my-way": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
-      "integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-querystring": "^1.0.0",
-        "safe-regex2": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/find-up": {
@@ -7641,6 +7221,16 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.32",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -7667,6 +7257,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
@@ -7809,16 +7406,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "devOptional": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -12217,17 +11804,17 @@
       }
     },
     "node_modules/prisma": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.9.0.tgz",
-      "integrity": "sha512-isQTJEK4pyOlAVzm6kBUDjzgdsgs0A/snpB38ycTHeOHW34qfepP+ClQltgDXqjZBnXALhEtE4duh9L3tN5fHw==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.8.0.tgz",
+      "integrity": "sha512-yfN4yrw7HV9kEJhoy1+jgah0jafEIQsf7uWouSsM8MvJtlubsk+kM7AIBWZ8+GJl74Yj3c+nbYqBkMOxtsZ3Lw==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "7.9.0",
-        "@prisma/dev": "0.24.14",
-        "@prisma/engines": "7.9.0",
-        "@prisma/studio-core": "0.33.0",
+        "@prisma/config": "7.8.0",
+        "@prisma/dev": "0.24.3",
+        "@prisma/engines": "7.8.0",
+        "@prisma/studio-core": "0.27.3",
         "mysql2": "3.15.3",
         "postgres": "3.4.7"
       },
@@ -12554,16 +12141,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/ret": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
-      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -12573,13 +12150,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "node_modules/robust-predicates": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
-      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
-      "devOptional": true,
-      "license": "Unlicense"
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -12625,29 +12195,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/safe-regex2": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
-      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
-      "devOptional": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "ret": "~0.5.0"
-      },
-      "bin": {
-        "safe-regex2": "bin/safe-regex2.js"
-      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",

--- a/stellance/backend/package.json
+++ b/stellance/backend/package.json
@@ -27,8 +27,8 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/swagger": "^11.2.6",
-    "@prisma/adapter-pg": "^7.9.0",
-    "@prisma/client": "^7.9.0",
+    "@prisma/adapter-pg": "7.8.0",
+    "@prisma/client": "7.8.0",
     "@stellar/stellar-sdk": "^13.3.0",
     "argon2": "^0.44.0",
     "class-transformer": "^0.5.1",
@@ -66,7 +66,7 @@
     "globals": "^16.0.0",
     "jest": "^30.0.0",
     "prettier": "^3.4.2",
-    "prisma": "^7.9.0",
+    "prisma": "7.8.0",
     "source-map-support": "^0.5.21",
     "supertest": "^7.0.0",
     "ts-jest": "^29.2.5",
@@ -77,7 +77,8 @@
     "typescript-eslint": "^8.20.0"
   },
   "overrides": {
-    "fast-uri": "3.1.4"
+    "fast-uri": "3.1.4",
+    "find-my-way": "9.7.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/stellance/frontend/app/(dashboard)/layout.tsx
+++ b/stellance/frontend/app/(dashboard)/layout.tsx
@@ -5,6 +5,7 @@ import {
   PostJobButton,
   PostJobButtonCompact,
 } from "./components/PostJobButton";
+import { WalletConnect } from "@/components/wallet/WalletConnect";
 
 export const metadata: Metadata = {
   title: {
@@ -136,24 +137,12 @@ function Sidebar() {
         </div>
       </nav>
 
-      {/* Footer: wallet / profile placeholder */}
+      {/* Footer: wallet connect */}
       <div
-        className="px-5 py-4 shrink-0"
+        className="px-4 py-4 shrink-0"
         style={{ borderTop: "1px solid var(--color-slate-border)" }}
       >
-        <div className="flex items-center gap-2.5">
-          <div
-            className="w-7 h-7 rounded-full shrink-0 flex items-center justify-center text-xs font-bold text-white"
-            style={{ background: "linear-gradient(135deg, #3da9fc, #5ee7ff)" }}
-            aria-hidden
-          >
-            S
-          </div>
-          <div className="min-w-0">
-            <p className="text-xs font-medium text-white truncate">My Account</p>
-            <p className="text-xs text-text-muted truncate">Freighter not connected</p>
-          </div>
-        </div>
+        <WalletConnect variant="full" />
       </div>
     </aside>
   );
@@ -198,6 +187,8 @@ function TopBar() {
         ))}
         {/* CLIENT-only: Post a Job CTA */}
         <PostJobButtonCompact />
+        {/* Wallet connect (compact pill for mobile) */}
+        <WalletConnect variant="compact" />
       </nav>
     </header>
   );

--- a/stellance/frontend/components/wallet/WalletBalance.tsx
+++ b/stellance/frontend/components/wallet/WalletBalance.tsx
@@ -1,0 +1,346 @@
+/**
+ * WalletBalance
+ *
+ * Displays the connected wallet's XLM balance.
+ *
+ * layout="card"   — standalone card surface (e.g. dashboard widgets)
+ * layout="inline" — compact row for use inside the WalletConnect dropdown
+ *
+ * Shows a skeleton pulse while loading, a muted dash when disconnected,
+ * and a refresh button to pull the latest balance on demand.
+ */
+
+"use client";
+
+import { useSyncExternalStore } from "react";
+import { useStellarWallet } from "@/hooks/useStellarWallet";
+
+// ─── Icons ────────────────────────────────────────────────────────────────────
+
+function XlmIcon({ size = 18 }: { size?: number }) {
+  // Stellar (XLM) logotype approximated as a simple glyph
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden
+    >
+      <path d="M12 2a10 10 0 1 0 10 10A10 10 0 0 0 12 2zm4.95 6.05-7.07 7.07-1.41-1.41 7.07-7.07zM7.05 8.46l7.07 7.07-1.41 1.42L5.64 9.88z" />
+    </svg>
+  );
+}
+
+function RefreshIcon({ size = 12 }: { size?: number }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <polyline points="23 4 23 10 17 10" />
+      <polyline points="1 20 1 14 7 14" />
+      <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+    </svg>
+  );
+}
+
+// ─── Skeleton ─────────────────────────────────────────────────────────────────
+
+function BalanceSkeleton({ inline }: { inline: boolean }) {
+  if (inline) {
+    return (
+      <div
+        aria-hidden
+        style={{
+          height: 14,
+          width: 72,
+          borderRadius: 4,
+          background: "rgba(36,53,84,0.8)",
+          animation: "pulse 1.5s ease-in-out infinite",
+        }}
+      />
+    );
+  }
+  return (
+    <div
+      aria-hidden
+      style={{
+        height: 28,
+        width: 120,
+        borderRadius: 6,
+        background: "rgba(36,53,84,0.8)",
+        animation: "pulse 1.5s ease-in-out infinite",
+      }}
+    />
+  );
+}
+
+// ─── WalletBalance ────────────────────────────────────────────────────────────
+
+export interface WalletBalanceProps {
+  /** "card" renders as a standalone card surface; "inline" is a compact row. */
+  layout?: "card" | "inline";
+}
+
+export function WalletBalance({ layout = "card" }: WalletBalanceProps) {
+  const { balance, isConnected, isLoadingBalance, refreshBalance } =
+    useStellarWallet();
+
+  // Prevent SSR mismatch — useSyncExternalStore avoids react-hooks/set-state-in-effect
+  const mounted = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false,
+  );
+
+  // ── Inline layout ─────────────────────────────────────────────────────────
+
+  if (layout === "inline") {
+    return (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: "0.5rem",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
+          <span style={{ color: "var(--color-text-muted)" }}>
+            <XlmIcon size={14} />
+          </span>
+          <span
+            style={{
+              fontSize: "0.7rem",
+              fontWeight: 600,
+              letterSpacing: "0.05em",
+              textTransform: "uppercase",
+              color: "var(--color-text-muted)",
+            }}
+          >
+            XLM Balance
+          </span>
+        </div>
+
+        <div style={{ display: "flex", alignItems: "center", gap: "0.375rem" }}>
+          {!mounted || isLoadingBalance ? (
+            <BalanceSkeleton inline />
+          ) : isConnected && balance ? (
+            <span
+              style={{
+                fontSize: "0.8125rem",
+                fontWeight: 700,
+                fontFamily: "var(--font-space-grotesk)",
+                color: "#2DD4BF",
+              }}
+            >
+              {balance} XLM
+            </span>
+          ) : (
+            <span
+              style={{
+                fontSize: "0.8125rem",
+                color: "var(--color-text-muted)",
+              }}
+            >
+              —
+            </span>
+          )}
+
+          {isConnected && (
+            <button
+              onClick={refreshBalance}
+              disabled={isLoadingBalance}
+              aria-label="Refresh XLM balance"
+              style={{
+                background: "none",
+                border: "none",
+                padding: "2px",
+                cursor: isLoadingBalance ? "not-allowed" : "pointer",
+                color: "var(--color-text-muted)",
+                display: "inline-flex",
+                alignItems: "center",
+                borderRadius: 4,
+                transition: "color 120ms",
+                opacity: isLoadingBalance ? 0.4 : 1,
+              }}
+              onMouseEnter={(e) => {
+                if (!isLoadingBalance)
+                  (e.currentTarget as HTMLButtonElement).style.color =
+                    "var(--color-accent)";
+              }}
+              onMouseLeave={(e) => {
+                (e.currentTarget as HTMLButtonElement).style.color =
+                  "var(--color-text-muted)";
+              }}
+            >
+              <RefreshIcon />
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // ── Card layout ───────────────────────────────────────────────────────────
+
+  return (
+    <section
+      className="card-surface"
+      style={{ padding: "1.25rem 1.5rem" }}
+      aria-label="XLM Balance"
+    >
+      {/* Header row */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: "0.875rem",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+          <span
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: 28,
+              height: 28,
+              borderRadius: "50%",
+              background: "rgba(45,212,191,0.12)",
+              color: "#2DD4BF",
+            }}
+          >
+            <XlmIcon size={16} />
+          </span>
+          <span
+            style={{
+              fontSize: "0.75rem",
+              fontWeight: 600,
+              letterSpacing: "0.06em",
+              textTransform: "uppercase",
+              color: "var(--color-text-muted)",
+            }}
+          >
+            XLM Balance
+          </span>
+        </div>
+
+        {isConnected && (
+          <button
+            onClick={refreshBalance}
+            disabled={isLoadingBalance}
+            aria-label="Refresh XLM balance"
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "0.25rem",
+              background: "none",
+              border: "none",
+              padding: "0.25rem 0.5rem",
+              borderRadius: "var(--radius-sm)",
+              cursor: isLoadingBalance ? "not-allowed" : "pointer",
+              color: "var(--color-text-muted)",
+              fontSize: "0.7rem",
+              transition: "color 120ms, background 120ms",
+              opacity: isLoadingBalance ? 0.5 : 1,
+            }}
+            onMouseEnter={(e) => {
+              if (!isLoadingBalance) {
+                const el = e.currentTarget as HTMLButtonElement;
+                el.style.color = "var(--color-accent)";
+                el.style.background = "rgba(61,169,252,0.08)";
+              }
+            }}
+            onMouseLeave={(e) => {
+              const el = e.currentTarget as HTMLButtonElement;
+              el.style.color = "var(--color-text-muted)";
+              el.style.background = "none";
+            }}
+          >
+            <RefreshIcon size={12} />
+            Refresh
+          </button>
+        )}
+      </div>
+
+      {/* Balance value */}
+      {!mounted || isLoadingBalance ? (
+        <BalanceSkeleton inline={false} />
+      ) : isConnected && balance ? (
+        <div style={{ display: "flex", alignItems: "baseline", gap: "0.4rem" }}>
+          <span
+            style={{
+              fontSize: "1.75rem",
+              fontWeight: 700,
+              fontFamily: "var(--font-space-grotesk)",
+              color: "#FFFFFF",
+              letterSpacing: "-0.02em",
+              lineHeight: 1,
+            }}
+          >
+            {balance}
+          </span>
+          <span
+            style={{
+              fontSize: "0.875rem",
+              fontWeight: 600,
+              color: "#2DD4BF",
+              letterSpacing: "0.04em",
+            }}
+          >
+            XLM
+          </span>
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+          <span
+            style={{
+              fontSize: "1.25rem",
+              fontWeight: 600,
+              color: "var(--color-text-muted)",
+            }}
+          >
+            — XLM
+          </span>
+          <p
+            style={{
+              fontSize: "0.75rem",
+              color: "var(--color-text-muted)",
+              marginTop: "0.25rem",
+            }}
+          >
+            Connect your Freighter wallet to see your balance.
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}
+
+// CSS for skeleton animation — injected once
+if (typeof document !== "undefined") {
+  const id = "stellance-pulse-keyframe";
+  if (!document.getElementById(id)) {
+    const style = document.createElement("style");
+    style.id = id;
+    style.textContent = `
+      @keyframes pulse {
+        0%, 100% { opacity: 1; }
+        50% { opacity: 0.4; }
+      }
+    `;
+    document.head.appendChild(style);
+  }
+}

--- a/stellance/frontend/components/wallet/WalletConnect.tsx
+++ b/stellance/frontend/components/wallet/WalletConnect.tsx
@@ -1,0 +1,518 @@
+/**
+ * WalletConnect
+ *
+ * "Connect Wallet" button for the dashboard navbar.
+ *
+ * States:
+ *  - idle / disconnected → blue "Connect Wallet" button
+ *  - checking            → spinner (non-interactive)
+ *  - connected           → pill showing truncated address + dropdown with
+ *                          full address, XLM balance, copy, and disconnect
+ *
+ * Renders nothing on the server (wallet state is browser-only), so it is
+ * wrapped in a no-SSR guard via useEffect + mounted flag.
+ */
+
+"use client";
+
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { useStellarWallet } from "@/hooks/useStellarWallet";
+import { WalletBalance } from "./WalletBalance";
+
+// ─── Icons ────────────────────────────────────────────────────────────────────
+
+function WalletIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M21 12V7H5a2 2 0 0 1 0-4h14v4" />
+      <path d="M3 5v14a2 2 0 0 0 2 2h16v-5" />
+      <path d="M18 12a2 2 0 1 0 4 0 2 2 0 0 0-4 0z" />
+    </svg>
+  );
+}
+
+function ChevronDownIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={12}
+      height={12}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}
+
+function CopyIcon({ size = 14 }: { size?: number }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+
+function DisconnectIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={14}
+      height={14}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+      <polyline points="16 17 21 12 16 7" />
+      <line x1="21" y1="12" x2="9" y2="12" />
+    </svg>
+  );
+}
+
+function RefreshIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={14}
+      height={14}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <polyline points="23 4 23 10 17 10" />
+      <polyline points="1 20 1 14 7 14" />
+      <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+    </svg>
+  );
+}
+
+// ─── Spinner ──────────────────────────────────────────────────────────────────
+
+function Spinner() {
+  return (
+    <span
+      aria-hidden
+      style={{
+        display: "inline-block",
+        width: 14,
+        height: 14,
+        borderRadius: "50%",
+        border: "2px solid rgba(61,169,252,0.3)",
+        borderTopColor: "#3DA9FC",
+        animation: "spin 0.7s linear infinite",
+      }}
+    />
+  );
+}
+
+// ─── Connected dropdown ───────────────────────────────────────────────────────
+
+interface ConnectedDropdownProps {
+  publicKey: string;
+  truncatedAddress: string;
+  onDisconnect: () => void;
+  onRefresh: () => void;
+}
+
+function ConnectedDropdown({
+  publicKey,
+  truncatedAddress,
+  onDisconnect,
+  onRefresh,
+}: ConnectedDropdownProps) {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    if (open) document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    if (open) document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open]);
+
+  const copyAddress = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(publicKey);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API unavailable
+    }
+  }, [publicKey]);
+
+  return (
+    <div ref={dropdownRef} style={{ position: "relative" }}>
+      {/* Trigger pill */}
+      <button
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="true"
+        aria-expanded={open}
+        aria-label="Wallet options"
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: "0.4rem",
+          padding: "0.375rem 0.75rem",
+          borderRadius: "9999px",
+          background: "rgba(61,169,252,0.12)",
+          border: "1px solid rgba(61,169,252,0.3)",
+          color: "#3DA9FC",
+          fontSize: "0.75rem",
+          fontWeight: 600,
+          fontFamily: "var(--font-space-grotesk)",
+          cursor: "pointer",
+          transition: "background 150ms",
+          letterSpacing: "0.01em",
+        }}
+        onMouseEnter={(e) => {
+          (e.currentTarget as HTMLButtonElement).style.background =
+            "rgba(61,169,252,0.2)";
+        }}
+        onMouseLeave={(e) => {
+          (e.currentTarget as HTMLButtonElement).style.background =
+            "rgba(61,169,252,0.12)";
+        }}
+      >
+        {/* Connected dot */}
+        <span
+          aria-hidden
+          style={{
+            width: 7,
+            height: 7,
+            borderRadius: "50%",
+            background: "#2DD4BF",
+            boxShadow: "0 0 6px rgba(45,212,191,0.8)",
+            flexShrink: 0,
+          }}
+        />
+        <span>{truncatedAddress}</span>
+        <span
+          style={{
+            transform: open ? "rotate(180deg)" : "rotate(0)",
+            transition: "transform 150ms",
+            display: "inline-flex",
+          }}
+        >
+          <ChevronDownIcon />
+        </span>
+      </button>
+
+      {/* Dropdown panel */}
+      {open && (
+        <div
+          role="menu"
+          aria-label="Wallet menu"
+          style={{
+            position: "absolute",
+            right: 0,
+            top: "calc(100% + 8px)",
+            minWidth: 260,
+            background: "var(--color-slate-panel)",
+            border: "1px solid var(--color-slate-border)",
+            borderRadius: "var(--radius-md)",
+            boxShadow: "0 8px 32px rgba(0,0,0,0.4), 0 0 0 1px rgba(61,169,252,0.06)",
+            zIndex: 50,
+            overflow: "hidden",
+          }}
+        >
+          {/* Address section */}
+          <div
+            style={{
+              padding: "0.875rem 1rem",
+              borderBottom: "1px solid var(--color-slate-border)",
+            }}
+          >
+            <p
+              style={{
+                fontSize: "0.65rem",
+                fontWeight: 600,
+                letterSpacing: "0.08em",
+                color: "var(--color-text-muted)",
+                marginBottom: "0.3rem",
+                textTransform: "uppercase",
+              }}
+            >
+              Connected wallet
+            </p>
+            <p
+              style={{
+                fontSize: "0.7rem",
+                fontFamily: "monospace",
+                color: "var(--color-text-primary)",
+                wordBreak: "break-all",
+                lineHeight: 1.5,
+              }}
+              title={publicKey}
+            >
+              {publicKey}
+            </p>
+          </div>
+
+          {/* Balance */}
+          <div
+            style={{
+              padding: "0.75rem 1rem",
+              borderBottom: "1px solid var(--color-slate-border)",
+            }}
+          >
+            <WalletBalance layout="inline" />
+          </div>
+
+          {/* Actions */}
+          <div style={{ padding: "0.375rem" }}>
+            <DropdownItem
+              icon={<CopyIcon />}
+              label={copied ? "Copied!" : "Copy address"}
+              onClick={copyAddress}
+            />
+            <DropdownItem
+              icon={<RefreshIcon />}
+              label="Refresh balance"
+              onClick={() => {
+                onRefresh();
+                setOpen(false);
+              }}
+            />
+            <DropdownItem
+              icon={<DisconnectIcon />}
+              label="Disconnect"
+              onClick={() => {
+                onDisconnect();
+                setOpen(false);
+              }}
+              danger
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Dropdown item ────────────────────────────────────────────────────────────
+
+function DropdownItem({
+  icon,
+  label,
+  onClick,
+  danger = false,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  danger?: boolean;
+}) {
+  const base: React.CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    gap: "0.625rem",
+    width: "100%",
+    padding: "0.5rem 0.625rem",
+    background: "transparent",
+    border: "none",
+    borderRadius: "var(--radius-sm)",
+    color: danger ? "var(--color-error)" : "var(--color-text-primary)",
+    fontSize: "0.8125rem",
+    cursor: "pointer",
+    textAlign: "left",
+    transition: "background 120ms",
+  };
+
+  return (
+    <button
+      role="menuitem"
+      onClick={onClick}
+      style={base}
+      onMouseEnter={(e) => {
+        (e.currentTarget as HTMLButtonElement).style.background = danger
+          ? "rgba(248,113,113,0.08)"
+          : "rgba(255,255,255,0.05)";
+      }}
+      onMouseLeave={(e) => {
+        (e.currentTarget as HTMLButtonElement).style.background = "transparent";
+      }}
+    >
+      <span style={{ color: danger ? "var(--color-error)" : "var(--color-text-muted)" }}>
+        {icon}
+      </span>
+      {label}
+    </button>
+  );
+}
+
+// ─── WalletConnect ────────────────────────────────────────────────────────────
+
+/**
+ * variant="full" — used in the sidebar footer (shows icon + label)
+ * variant="compact" — used in the mobile topbar (icon + short label)
+ */
+export interface WalletConnectProps {
+  variant?: "full" | "compact";
+}
+
+export function WalletConnect({ variant = "full" }: WalletConnectProps) {
+  const { publicKey, truncatedAddress, isConnected, isChecking, error, connect, disconnect, refreshBalance } =
+    useStellarWallet();
+
+  // Avoid SSR mismatch: render nothing until client-side mount.
+  // useSyncExternalStore returns false on the server and true on the client,
+  // which is both hydration-safe and avoids react-hooks/set-state-in-effect.
+  const mounted = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false,
+  );
+  if (!mounted) return null;
+
+  // ── Checking / loading state ───────────────────────────────────────────────
+  if (isChecking) {
+    return (
+      <div
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: "0.5rem",
+          padding: variant === "compact" ? "0.375rem 0.625rem" : "0.5rem 0.875rem",
+          borderRadius: "9999px",
+          background: "rgba(61,169,252,0.06)",
+          border: "1px solid rgba(61,169,252,0.15)",
+          color: "var(--color-text-muted)",
+          fontSize: "0.75rem",
+        }}
+        aria-label="Checking wallet connection"
+      >
+        <Spinner />
+        {variant === "full" && <span>Connecting…</span>}
+      </div>
+    );
+  }
+
+  // ── Connected state ────────────────────────────────────────────────────────
+  if (isConnected && publicKey && truncatedAddress) {
+    return (
+      <ConnectedDropdown
+        publicKey={publicKey}
+        truncatedAddress={truncatedAddress}
+        onDisconnect={disconnect}
+        onRefresh={refreshBalance}
+      />
+    );
+  }
+
+  // ── Disconnected / idle state ──────────────────────────────────────────────
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "0.375rem" }}>
+      <button
+        onClick={connect}
+        aria-label="Connect Freighter wallet"
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: "0.4rem",
+          padding: variant === "compact" ? "0.375rem 0.625rem" : "0.5rem 0.875rem",
+          borderRadius: "9999px",
+          background: "linear-gradient(135deg, #3DA9FC, #5EE7FF)",
+          border: "none",
+          color: "#0B1E3D",
+          fontSize: "0.75rem",
+          fontWeight: 700,
+          fontFamily: "var(--font-space-grotesk)",
+          cursor: "pointer",
+          transition: "opacity 150ms, box-shadow 150ms",
+          letterSpacing: "0.01em",
+          whiteSpace: "nowrap",
+        }}
+        onMouseEnter={(e) => {
+          (e.currentTarget as HTMLButtonElement).style.opacity = "0.88";
+          (e.currentTarget as HTMLButtonElement).style.boxShadow =
+            "0 0 16px rgba(61,169,252,0.5)";
+        }}
+        onMouseLeave={(e) => {
+          (e.currentTarget as HTMLButtonElement).style.opacity = "1";
+          (e.currentTarget as HTMLButtonElement).style.boxShadow = "none";
+        }}
+      >
+        <WalletIcon size={14} />
+        {variant === "compact" ? "Connect" : "Connect Wallet"}
+      </button>
+
+      {/* Inline error message */}
+      {error && (
+        <p
+          role="alert"
+          style={{
+            fontSize: "0.65rem",
+            color: "var(--color-error)",
+            lineHeight: 1.4,
+            maxWidth: 200,
+          }}
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// CSS animation for spinner — injected once at module level
+if (typeof document !== "undefined") {
+  const id = "stellance-spin-keyframe";
+  if (!document.getElementById(id)) {
+    const style = document.createElement("style");
+    style.id = id;
+    style.textContent = `@keyframes spin { to { transform: rotate(360deg); } }`;
+    document.head.appendChild(style);
+  }
+}

--- a/stellance/frontend/hooks/useStellarWallet.ts
+++ b/stellance/frontend/hooks/useStellarWallet.ts
@@ -1,0 +1,222 @@
+/**
+ * useStellarWallet
+ *
+ * React hook that wires the Freighter browser extension to the Zustand wallet
+ * store.  All side-effectful operations (connecting, disconnecting, balance
+ * fetches) live here; the store is kept as pure state.
+ *
+ * Freighter does not ship its own @types package, so the browser API is
+ * typed via the FreighterApi interface below using the Freighter JS API docs.
+ *
+ * Horizon balance fetch uses @stellar/stellar-sdk already in the project.
+ */
+
+"use client";
+
+import { useCallback, useEffect } from "react";
+import { Horizon } from "@stellar/stellar-sdk";
+import { useWalletStore } from "@/lib/stores/walletStore";
+
+// ─── Freighter browser API types ──────────────────────────────────────────────
+
+interface FreighterApi {
+  /** Returns the public key of the connected account. */
+  getPublicKey(): Promise<string>;
+  /** Returns true when the user has granted the site permission. */
+  isConnected(): Promise<boolean | { isConnected: boolean }>;
+  /** Prompts the user to grant the site permission to read their public key. */
+  requestAccess(): Promise<string>;
+  /** Returns the network the wallet is on ("TESTNET" | "PUBLIC" | …). */
+  getNetwork(): Promise<string>;
+}
+
+declare global {
+  interface Window {
+    freighter?: FreighterApi;
+  }
+}
+
+// ─── Horizon server ───────────────────────────────────────────────────────────
+
+// Use testnet by default; swap for PUBLIC_HORIZON_URL in production.
+const HORIZON_URL =
+  process.env.NEXT_PUBLIC_HORIZON_URL ?? "https://horizon-testnet.stellar.org";
+
+const horizon = new Horizon.Server(HORIZON_URL, { allowHttp: false });
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Safely detect whether Freighter is installed in the current browser. */
+function isFreighterInstalled(): boolean {
+  return typeof window !== "undefined" && typeof window.freighter !== "undefined";
+}
+
+/**
+ * Normalise isConnected() return value.
+ *
+ * Freighter's JS SDK ≥ 1.7 returns `{ isConnected: boolean }`.
+ * Older versions return a plain boolean.  Handle both.
+ */
+function parseIsConnected(result: boolean | { isConnected: boolean }): boolean {
+  if (typeof result === "boolean") return result;
+  return result.isConnected;
+}
+
+/** Format a raw XLM balance string to 7 decimal places maximum. */
+function formatXlm(raw: string): string {
+  const n = parseFloat(raw);
+  if (isNaN(n)) return raw;
+  // Strip trailing zeros but keep at least 2 decimal places
+  return n.toLocaleString("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 7,
+  });
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+export function useStellarWallet() {
+  const {
+    publicKey,
+    balance,
+    status,
+    isLoadingBalance,
+    error,
+    setConnected,
+    setBalance,
+    setStatus,
+    setLoadingBalance,
+    setError,
+    disconnect,
+  } = useWalletStore();
+
+  // ── Fetch XLM balance from Horizon ────────────────────────────────────────
+
+  const fetchBalance = useCallback(
+    async (key: string) => {
+      setLoadingBalance(true);
+      try {
+        const account = await horizon.loadAccount(key);
+        const xlmBalance = account.balances.find(
+          (b) => b.asset_type === "native"
+        );
+        setBalance(xlmBalance ? formatXlm(xlmBalance.balance) : "0.00");
+      } catch {
+        // Non-fatal: wallet can be connected even if Horizon is unreachable
+        setBalance("—");
+      } finally {
+        setLoadingBalance(false);
+      }
+    },
+    [setBalance, setLoadingBalance]
+  );
+
+  // ── Connect ───────────────────────────────────────────────────────────────
+
+  const connect = useCallback(async () => {
+    if (!isFreighterInstalled()) {
+      setError(
+        "Freighter wallet not found. Install it at freighter.app and reload."
+      );
+      setStatus("disconnected");
+      return;
+    }
+
+    setStatus("checking");
+    setError(null);
+
+    try {
+      // requestAccess() shows the Freighter permission modal if needed and
+      // returns the public key on success.
+      const key = await window.freighter!.requestAccess();
+      if (!key) throw new Error("Access denied.");
+      setConnected(key);
+      await fetchBalance(key);
+    } catch (err: unknown) {
+      const msg =
+        err instanceof Error ? err.message : "Failed to connect wallet.";
+      setError(msg);
+      setStatus("disconnected");
+    }
+  }, [setConnected, setStatus, setError, fetchBalance]);
+
+  // ── Disconnect ────────────────────────────────────────────────────────────
+
+  const handleDisconnect = useCallback(() => {
+    // Freighter has no programmatic disconnect; we just clear local state.
+    disconnect();
+  }, [disconnect]);
+
+  // ── Refresh balance ───────────────────────────────────────────────────────
+
+  const refreshBalance = useCallback(async () => {
+    if (publicKey) await fetchBalance(publicKey);
+  }, [publicKey, fetchBalance]);
+
+  // ── Auto-reconnect on mount ───────────────────────────────────────────────
+  // If the user already granted access in a previous session, silently
+  // restore their public key without showing the Freighter modal again.
+
+  useEffect(() => {
+    if (status !== "idle") return;
+    if (!isFreighterInstalled()) {
+      setStatus("disconnected");
+      return;
+    }
+
+    let cancelled = false;
+
+    (async () => {
+      setStatus("checking");
+      try {
+        const result = await window.freighter!.isConnected();
+        if (cancelled) return;
+
+        if (parseIsConnected(result)) {
+          const key = await window.freighter!.getPublicKey();
+          if (cancelled) return;
+          if (key) {
+            setConnected(key);
+            await fetchBalance(key);
+          } else {
+            setStatus("disconnected");
+          }
+        } else {
+          setStatus("disconnected");
+        }
+      } catch {
+        if (!cancelled) setStatus("disconnected");
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [status, setConnected, setStatus, fetchBalance]);
+
+  // ── Derived helpers ───────────────────────────────────────────────────────
+
+  /** Truncated address for display: "GABCD…WXYZ" */
+  const truncatedAddress = publicKey
+    ? `${publicKey.slice(0, 4)}…${publicKey.slice(-4)}`
+    : null;
+
+  const isConnected = status === "connected";
+  const isChecking = status === "checking";
+
+  return {
+    // State
+    publicKey,
+    truncatedAddress,
+    balance,
+    status,
+    isConnected,
+    isChecking,
+    isLoadingBalance,
+    error,
+    // Actions
+    connect,
+    disconnect: handleDisconnect,
+    refreshBalance,
+  };
+}

--- a/stellance/frontend/lib/stores/walletStore.ts
+++ b/stellance/frontend/lib/stores/walletStore.ts
@@ -1,0 +1,73 @@
+/**
+ * Zustand store for Stellar wallet state.
+ *
+ * Holds the connected wallet's public key, XLM balance, and connection status.
+ * Kept deliberately flat — all side-effectful operations (Freighter calls,
+ * Horizon balance fetch) live in the useStellarWallet hook, not here.
+ */
+
+import { create } from "zustand";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type WalletStatus =
+  | "idle"        // not yet checked
+  | "checking"    // probing Freighter on mount
+  | "connected"   // wallet connected, publicKey is set
+  | "disconnected"; // user disconnected, or Freighter not installed
+
+export interface WalletState {
+  /** Stellar G-address of the connected account, or null when disconnected. */
+  publicKey: string | null;
+  /** Native XLM balance as a human-readable string (e.g. "42.1234567"), or null. */
+  balance: string | null;
+  /** Connection lifecycle status. */
+  status: WalletStatus;
+  /** True while a balance fetch is in flight. */
+  isLoadingBalance: boolean;
+  /** Error message from the last failed operation, if any. */
+  error: string | null;
+}
+
+export interface WalletActions {
+  setConnected: (publicKey: string) => void;
+  setBalance: (balance: string) => void;
+  setStatus: (status: WalletStatus) => void;
+  setLoadingBalance: (loading: boolean) => void;
+  setError: (error: string | null) => void;
+  disconnect: () => void;
+}
+
+// ─── Store ────────────────────────────────────────────────────────────────────
+
+export const useWalletStore = create<WalletState & WalletActions>()((set) => ({
+  // ── Initial state ──────────────────────────────────────────────────────────
+  publicKey: null,
+  balance: null,
+  status: "idle",
+  isLoadingBalance: false,
+  error: null,
+
+  // ── Actions ────────────────────────────────────────────────────────────────
+
+  setConnected: (publicKey) =>
+    set({ publicKey, status: "connected", error: null }),
+
+  setBalance: (balance) => set({ balance }),
+
+  setStatus: (status) => set({ status }),
+
+  setLoadingBalance: (isLoadingBalance) => set({ isLoadingBalance }),
+
+  setError: (error) => set({ error }),
+
+  /** Fully reset wallet state to the disconnected baseline. */
+  disconnect: () =>
+    set({
+      publicKey: null,
+      balance: null,
+      status: "disconnected",
+      isLoadingBalance: false,
+      error: null,
+    }),
+}));

--- a/stellance/frontend/package-lock.json
+++ b/stellance/frontend/package-lock.json
@@ -16,7 +16,8 @@
         "react-dom": "19.2.3",
         "react-hook-form": "^7.56.4",
         "sonner": "^2.0.7",
-        "zod": "^3.25.76"
+        "zod": "^3.25.76",
+        "zustand": "5.0.5"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -1780,7 +1781,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2788,7 +2789,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -7209,6 +7210,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.5.tgz",
+      "integrity": "sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/stellance/frontend/package.json
+++ b/stellance/frontend/package.json
@@ -17,7 +17,8 @@
     "react-dom": "19.2.3",
     "react-hook-form": "^7.56.4",
     "sonner": "^2.0.7",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "zustand": "5.0.5"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary

Implements the wallet connection component allowing users to connect or create a Stellar wallet via the Freighter browser extension.

## Changes

**`lib/stores/walletStore.ts`** — Zustand store for wallet state
- Flat state: `publicKey`, `balance`, `status`, `isLoadingBalance`, `error`
- Pure setter actions; all side effects live in the hook, not the store

**`hooks/useStellarWallet.ts`** — Freighter + Horizon integration
- Manual `window.freighter` TypeScript declarations (no external types pkg needed)
- Silent auto-reconnect on mount if the user already granted permission
- `connect()` triggers the Freighter permission modal via `requestAccess()`
- XLM balance fetched from Horizon (testnet by default, `NEXT_PUBLIC_HORIZON_URL` configurable)
- `disconnect()` / `refreshBalance()` actions

**`components/wallet/WalletConnect.tsx`** — Connect button for the navbar
- `variant="full"` for the sidebar, `variant="compact"` for the mobile topbar
- Three states: disconnected button → checking spinner → connected pill
- Connected dropdown: full address, inline balance, copy address, refresh, disconnect
- SSR-safe via `useSyncExternalStore` (avoids `react-hooks/set-state-in-effect`)

**`components/wallet/WalletBalance.tsx`** — XLM balance display
- `layout="card"` for standalone dashboard widgets
- `layout="inline"` for use inside the WalletConnect dropdown
- Skeleton pulse while loading; muted dash when disconnected

**`app/(dashboard)/layout.tsx`** — Wired into existing navbar
- Sidebar footer: wallet placeholder replaced with `<WalletConnect variant="full" />`
- Mobile TopBar: `<WalletConnect variant="compact" />` added alongside existing nav

## Testing

- Build: ✅ `npm run build` passes (Next.js 16 + Turbopack, 0 TypeScript errors)
- Lint: ✅ `npm run lint` — 0 errors (2 pre-existing react-hook-form warnings, unrelated)

Closes #8